### PR TITLE
UI refresh and Portal Nexus on Tree's/Fruit Tree's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .gradle
 build
-.idea/
+**/.idea/workspace.xml
+**/.idea/tasks.xml
 .project
 .settings/
 .classpath

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,19 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <codeStyleSettings language="JAVA">
+      <option name="KEEP_LINE_BREAKS" value="false" />
+      <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
+      <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+      <option name="CLASS_BRACE_STYLE" value="2" />
+      <option name="METHOD_BRACE_STYLE" value="2" />
+      <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+      <option name="SPACE_AROUND_UNARY_OPERATOR" value="true" />
+      <option name="CALL_PARAMETERS_WRAP" value="2" />
+      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.20/18bcea7d5df4d49227b4a0743a536208ce4825bb/lombok-1.18.20.jar" />
+        </processorPath>
+        <module name="Farming-Helper.main" />
+      </profile>
+    </annotationProcessing>
+    <bytecodeTargetLevel target="1.8" />
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://repo.runelite.net" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenLocal" />
+      <option name="name" value="MavenLocal" />
+      <option name="url" value="file:$MAVEN_REPOSITORY$/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="corretto-17" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,6 @@
 displayName=Lazy Farming
 author=Speaax
-support=
-description= Item and overlay for farm runs. (Incomplete!)
+support=https://github.com/Speaax/Farming-Helper/issues
+description= Item and overlay for farm runs.
 tags=Farming, Overlay
 plugins=com.farminghelper.speaax.FarmingHelperPlugin

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'example'
+rootProject.name = 'Farming-Helper'

--- a/src/main/java/com/farminghelper/speaax/FarmingHelperConfig.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingHelperConfig.java
@@ -336,6 +336,7 @@ public interface FarmingHelperConfig extends Config
 
 	enum OptionEnumArdougneTeleport implements OptionEnumTeleport
 	{
+		Portal_Nexus,
 		Ardougne_teleport,
 		Ardougne_tele_tab,
 		Ardy_cloak_2,
@@ -369,6 +370,7 @@ public interface FarmingHelperConfig extends Config
 
 	enum OptionEnumFaladorTeleport implements OptionEnumTeleport
 	{
+		Portal_Nexus,
 		Explorers_ring_2,
 		Explorers_ring_3,
 		Explorers_ring_4,
@@ -476,6 +478,7 @@ public interface FarmingHelperConfig extends Config
 	String treeTeleportOptionList = "treeTeleportOptionList";
 	enum TreeOptionEnumFaladorTeleport implements OptionEnumTeleport
 	{
+		Portal_Nexus,
 		Falador_teleport
 	}
 	@ConfigItem(
@@ -515,6 +518,7 @@ public interface FarmingHelperConfig extends Config
 
 	enum TreeOptionEnumLumbridgeTeleport implements OptionEnumTeleport
 	{
+		Portal_Nexus,
 		Lumbridge_teleport
 	}
 	@ConfigItem(
@@ -528,6 +532,7 @@ public interface FarmingHelperConfig extends Config
 
 	enum TreeOptionEnumTaverleyTeleport implements OptionEnumTeleport
 	{
+		Portal_Nexus,
 		Falador_teleport
 	}
 	@ConfigItem(
@@ -541,6 +546,7 @@ public interface FarmingHelperConfig extends Config
 
 	enum TreeOptionEnumVarrockTeleport implements OptionEnumTeleport
 	{
+		Portal_Nexus,
 		Varrock_teleport
 	}
 	@ConfigItem(
@@ -561,6 +567,7 @@ public interface FarmingHelperConfig extends Config
 
 	enum FruitTreeOptionEnumBrimhavenTeleport implements OptionEnumTeleport
 	{
+		Portal_Nexus,
 		Ardougne_teleport
 	}
 	@ConfigItem(
@@ -574,7 +581,7 @@ public interface FarmingHelperConfig extends Config
 
 	enum FruitTreeOptionEnumCatherbyTeleport implements OptionEnumTeleport
 	{
-		Portal_nexus
+		Portal_Nexus
 	}
 	@ConfigItem(
 			position = 1,
@@ -583,7 +590,7 @@ public interface FarmingHelperConfig extends Config
 			description = "Desired way to teleport to Catherby",
 			section = fruitTreeTeleportOptionList
 	)
-	default FruitTreeOptionEnumCatherbyTeleport enumFruitTreeCatherbyTeleport() { return FruitTreeOptionEnumCatherbyTeleport.Portal_nexus; }
+	default FruitTreeOptionEnumCatherbyTeleport enumFruitTreeCatherbyTeleport() { return FruitTreeOptionEnumCatherbyTeleport.Portal_Nexus; }
 
 	enum FruitTreeOptionEnumFarmingGuildTeleport implements OptionEnumTeleport
 	{

--- a/src/main/java/com/farminghelper/speaax/FarmingHelperConfig.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingHelperConfig.java
@@ -149,7 +149,7 @@ public interface FarmingHelperConfig extends Config
 		position = 4,
 		keyName = "booleanConfigFarmingGuildHerb",
 		name = "Farming Guild",
-		description = "Include Farming guild?(Requires level 65 farming and 60% Hosidious favour)",
+		description = "Include Farming guild? (Requires level 65 farming and 60% Hosidious favour)",
 		section = herbList
 	)
 	default boolean farmingGuildHerb() { return false; }
@@ -158,7 +158,7 @@ public interface FarmingHelperConfig extends Config
 		position = 5,
 		keyName = "booleanConfigHarmonyHerb",
 		name = "Harmony",
-		description = "Include Harmony?(Requires elite Morytania diary)",
+		description = "Include Harmony? (Requires elite Morytania diary)",
 		section = herbList
 	)
 	default boolean harmonyHerb() { return false; }
@@ -194,7 +194,7 @@ public interface FarmingHelperConfig extends Config
 		position = 9,
 		keyName = "booleanConfigWeissHerb",
 		name = "Weiss",
-		description = "Include Weiss?(Requires completion of Making Friends with My Arm, and The Fire of Nourishment must be built)",
+		description = "Include Weiss? (Requires completion of Making Friends with My Arm, and The Fire of Nourishment must be built)",
 		section = herbList
 	)
 	default boolean weissHerb() { return false; }
@@ -219,7 +219,7 @@ public interface FarmingHelperConfig extends Config
 		position = 11,
 		keyName = "booleanConfigFarmingGuildTree",
 		name = "Farming guild",
-		description = "Include Farming Guild?(Requires 65 farming)",
+		description = "Include Farming Guild? (Requires 65 farming)",
 		section = treeList
 	)
 	default boolean farmingGuildTree() { return false; }
@@ -294,7 +294,7 @@ public interface FarmingHelperConfig extends Config
 		position = 18,
 		keyName = "booleanConfigFarmingGuildFruitTree",
 		name = "Farming Guild",
-		description = "Include Farming Guild?(Requires 85 farming)",
+		description = "Include Farming Guild? (Requires 85 farming)",
 		section = fruitTreeList
 	)
 	default boolean farmingGuildFruitTree() { return false; }
@@ -312,7 +312,7 @@ public interface FarmingHelperConfig extends Config
 		position = 20,
 		keyName = "booleanConfigLletyaFruitTree",
 		name = "Lletya",
-		description = "Include Lletya?(Requires starting Mourning's End Part I)",
+		description = "Include Lletya? (Requires starting Mourning's End Part I)",
 		section = fruitTreeList
 	)
 	default boolean lletyaFruitTree() { return false; }

--- a/src/main/java/com/farminghelper/speaax/FarmingHelperConfig.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingHelperConfig.java
@@ -354,7 +354,8 @@ public interface FarmingHelperConfig extends Config
 	default OptionEnumArdougneTeleport enumOptionEnumArdougneTeleport() { return OptionEnumArdougneTeleport.Ardy_cloak_3; }
 	enum OptionEnumCatherbyTeleport implements OptionEnumTeleport
 	{
-		Portal_Nexus,
+		Portal_Nexus_Catherby,
+		Portal_Nexus_Camelot,
 		Camelot_Teleport,
 		Camelot_Tele_Tab,
 		Catherby_Tele_Tab
@@ -366,7 +367,7 @@ public interface FarmingHelperConfig extends Config
 			description = "Desired way to teleport to Catherby",
 			section = teleportOptionList
 	)
-	default OptionEnumCatherbyTeleport enumOptionEnumCatherbyTeleport() { return OptionEnumCatherbyTeleport.Portal_Nexus; }
+	default OptionEnumCatherbyTeleport enumOptionEnumCatherbyTeleport() { return OptionEnumCatherbyTeleport.Portal_Nexus_Catherby; }
 
 	enum OptionEnumFaladorTeleport implements OptionEnumTeleport
 	{
@@ -581,7 +582,8 @@ public interface FarmingHelperConfig extends Config
 
 	enum FruitTreeOptionEnumCatherbyTeleport implements OptionEnumTeleport
 	{
-		Portal_Nexus
+		Portal_Nexus_Catherby,
+		Portal_Nexus_Camelot
 	}
 	@ConfigItem(
 			position = 1,
@@ -590,7 +592,7 @@ public interface FarmingHelperConfig extends Config
 			description = "Desired way to teleport to Catherby",
 			section = fruitTreeTeleportOptionList
 	)
-	default FruitTreeOptionEnumCatherbyTeleport enumFruitTreeCatherbyTeleport() { return FruitTreeOptionEnumCatherbyTeleport.Portal_Nexus; }
+	default FruitTreeOptionEnumCatherbyTeleport enumFruitTreeCatherbyTeleport() { return FruitTreeOptionEnumCatherbyTeleport.Portal_Nexus_Catherby; }
 
 	enum FruitTreeOptionEnumFarmingGuildTeleport implements OptionEnumTeleport
 	{

--- a/src/main/java/com/farminghelper/speaax/FarmingHelperPanel.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingHelperPanel.java
@@ -4,6 +4,7 @@ import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -32,18 +33,58 @@ public class FarmingHelperPanel extends PluginPanel
         this.treeRunItemAndLocation = treeRunItemAndLocation;
         this.farmingTeleportOverlay = farmingTeleportOverlay;
         this.fruitTreeRunItemAndLocation = fruitTreeRunItemAndLocation;
+
         this.plugin = plugin;
         this.overlayManager = overlayManager;
-        setLayout(new GridBagLayout());
 
-        GridBagConstraints c = new GridBagConstraints();
-        c.fill = GridBagConstraints.HORIZONTAL;
-        c.insets = new Insets(0, 2, 4, 2);
+        setLayout(new BorderLayout());
+        setBorder(new EmptyBorder(10, 10, 10, 10));
 
-        c.gridx = 0;
-        c.gridy = 0;
+        JPanel layoutPanel = new JPanel();
+        layoutPanel.setLayout(new BoxLayout(layoutPanel, BoxLayout.Y_AXIS));
 
-        herbButton = new JButton("Herb run");
+        JPanel titlePanel = createTitlePanel();
+        JPanel farmRunButtons = createFarmRunButtons();
+        JPanel infoPanel = createInfoPanel();
+
+        layoutPanel.add(titlePanel);
+        layoutPanel.add(farmRunButtons);
+        layoutPanel.add(infoPanel);
+
+        add(layoutPanel, BorderLayout.NORTH);
+    }
+
+    private JPanel createTitlePanel()
+    {
+        JPanel titlePanel = new JPanel();
+        titlePanel.setBorder(new EmptyBorder(0, 0, 15, 0));
+        titlePanel.setLayout(new BorderLayout());
+
+        JLabel title = new JLabel("Start a new run farm run:");
+        titlePanel.add(title, BorderLayout.WEST);
+
+        return titlePanel;
+    }
+
+    private JPanel createFarmRunButtons()
+    {
+        JPanel farmRunButtonsContainingPanel = new JPanel();
+        farmRunButtonsContainingPanel.setLayout(new BoxLayout(farmRunButtonsContainingPanel, BoxLayout.Y_AXIS));
+
+        // With GridLayout, you can't set the button height.
+        // With GridBagLayout, you can't make the buttons the full width of the container.
+        // The height seemed like the better thing to let go of.
+//        JPanel farmRunButtonsPanel = new JPanel(new GridBagLayout());
+        JPanel farmRunButtonsPanel = new JPanel(new GridLayout(0, 1, 0, 15));
+        farmRunButtonsPanel.setBorder(new EmptyBorder(0, 0, 0, 0));
+
+//        GridBagConstraints constraints = new GridBagConstraints();
+//        constraints.insets = new Insets(5, 0, 5, 0);
+//        constraints.fill = GridBagConstraints.HORIZONTAL;
+//        constraints.gridwidth = 1;
+//        constraints.ipady = 10;
+
+        herbButton = new JButton("Herb Run");
 		herbButton.setFocusable(false);
         herbButton.addActionListener(new ActionListener() {
             @Override
@@ -56,22 +97,11 @@ public class FarmingHelperPanel extends PluginPanel
                 });
             }
         });
+//        constraints.gridy = 0;
+//        farmRunButtonsPanel.add(herbButton, constraints);
+        farmRunButtonsPanel.add(herbButton);
 
-        add(herbButton, c);
-
-        JLabel textLabel = new JLabel("Tree/Fruit Tree run is not recommended.");
-
-        c.gridx = 0;
-        c.gridy = 1;
-
-        add(textLabel, c);
-
-
-		c.gridx = 0;
-		c.gridy = 2;
-
-
-		treeButton = new JButton("Tree run");
+		treeButton = new JButton("Tree Run");
         treeButton.setFocusable(false);
         treeButton.addActionListener(new ActionListener()
         {
@@ -85,14 +115,11 @@ public class FarmingHelperPanel extends PluginPanel
                 });
             }
         });
+//        constraints.gridy = 1;
+//        farmRunButtonsPanel.add(treeButton, constraints);
+        farmRunButtonsPanel.add(treeButton);
 
-		add(treeButton, c);
-
-		c.gridx = 0;
-		c.gridy = 3;
-
-		
-		fruitTreeButton = new JButton("Fruit Tree run");
+		fruitTreeButton = new JButton("Fruit Tree Run");
         fruitTreeButton.setFocusable(false);
         fruitTreeButton.addActionListener(new ActionListener()
         {
@@ -106,19 +133,32 @@ public class FarmingHelperPanel extends PluginPanel
                 });
             }
         });
+//        constraints.gridy = 2;
+//        farmRunButtonsPanel.add(fruitTreeButton, constraints);
+        farmRunButtonsPanel.add(fruitTreeButton);
 
-        add(fruitTreeButton, c);
+        farmRunButtonsContainingPanel.add(farmRunButtonsPanel);
+
+        return farmRunButtonsContainingPanel;
+    }
+
+    private JPanel createInfoPanel()
+    {
+        JPanel infoContainingPanel = new JPanel();
+        infoContainingPanel.setLayout(new BoxLayout(infoContainingPanel, BoxLayout.Y_AXIS));
+        
+        JPanel infoPanel = new JPanel(new GridLayout(0, 1, 0, 0));
+        infoPanel.setBorder(new EmptyBorder(25, 0, 0, 0));
 
         JTextArea textAreaTip = new JTextArea("Tips: \n - Rune pouch and combination runes work. \n - If you don't have Bottomless compost bucket you should store compost @ Tool Leprechaun, the plugin checks if you have compost stored there.");
         textAreaTip.setWrapStyleWord(true);
         textAreaTip.setLineWrap(true);
         textAreaTip.setEditable(false);
+        infoPanel.add(textAreaTip);
 
+        infoContainingPanel.add(infoPanel);
 
-        c.gridx = 0;
-        c.gridy = 6;
-
-        add(textAreaTip, c);
+        return infoContainingPanel;
     }
 
     private void onHerbButtonClicked() {

--- a/src/main/java/com/farminghelper/speaax/FarmingHelperPanel.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingHelperPanel.java
@@ -60,7 +60,7 @@ public class FarmingHelperPanel extends PluginPanel
         titlePanel.setBorder(new EmptyBorder(0, 0, 15, 0));
         titlePanel.setLayout(new BorderLayout());
 
-        JLabel title = new JLabel("Pick a new run farm run:");
+        JLabel title = new JLabel("Pick a new farm run:");
         titlePanel.add(title, BorderLayout.WEST);
 
         return titlePanel;

--- a/src/main/java/com/farminghelper/speaax/FarmingHelperPanel.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingHelperPanel.java
@@ -60,7 +60,7 @@ public class FarmingHelperPanel extends PluginPanel
         titlePanel.setBorder(new EmptyBorder(0, 0, 15, 0));
         titlePanel.setLayout(new BorderLayout());
 
-        JLabel title = new JLabel("Start a new run farm run:");
+        JLabel title = new JLabel("Pick a new run farm run:");
         titlePanel.add(title, BorderLayout.WEST);
 
         return titlePanel;
@@ -84,7 +84,7 @@ public class FarmingHelperPanel extends PluginPanel
 //        constraints.gridwidth = 1;
 //        constraints.ipady = 10;
 
-        herbButton = new JButton("Herb Run");
+        StartStopJButton herbButton = new StartStopJButton("Herb Run");
 		herbButton.setFocusable(false);
         herbButton.addActionListener(new ActionListener() {
             @Override
@@ -93,6 +93,9 @@ public class FarmingHelperPanel extends PluginPanel
                     Map<Integer, Integer> herbItems = herbRunItemAndLocation.getHerbItems();
                     plugin.updateHerbOverlay(herbItems);
                     plugin.setOverlayActive(!plugin.isOverlayActive());
+
+                    herbButton.setStartStopState(plugin.isOverlayActive());
+
                     onHerbButtonClicked();
                 });
             }
@@ -101,7 +104,7 @@ public class FarmingHelperPanel extends PluginPanel
 //        farmRunButtonsPanel.add(herbButton, constraints);
         farmRunButtonsPanel.add(herbButton);
 
-		treeButton = new JButton("Tree Run");
+        StartStopJButton treeButton = new StartStopJButton("Tree Run");
         treeButton.setFocusable(false);
         treeButton.addActionListener(new ActionListener()
         {
@@ -111,6 +114,9 @@ public class FarmingHelperPanel extends PluginPanel
                     Map<Integer, Integer> treeItems = treeRunItemAndLocation.getTreeItems();
                     plugin.updateTreeOverlay(treeItems);
                     plugin.setOverlayActive(!plugin.isOverlayActive());
+
+                    treeButton.setStartStopState(plugin.isOverlayActive());
+
                     onTreeButtonClicked();
                 });
             }
@@ -119,7 +125,7 @@ public class FarmingHelperPanel extends PluginPanel
 //        farmRunButtonsPanel.add(treeButton, constraints);
         farmRunButtonsPanel.add(treeButton);
 
-		fruitTreeButton = new JButton("Fruit Tree Run");
+        StartStopJButton fruitTreeButton = new StartStopJButton("Fruit Tree Run");
         fruitTreeButton.setFocusable(false);
         fruitTreeButton.addActionListener(new ActionListener()
         {
@@ -129,6 +135,9 @@ public class FarmingHelperPanel extends PluginPanel
                     Map<Integer, Integer> fruitTreeItems = fruitTreeRunItemAndLocation.getFruitTreeItems();
                     plugin.updateFruitTreeOverlay(fruitTreeItems);
                     plugin.setOverlayActive(!plugin.isOverlayActive());
+
+                    fruitTreeButton.setStartStopState(plugin.isOverlayActive());
+
                     onFruitTreeButtonClicked();
                 });
             }

--- a/src/main/java/com/farminghelper/speaax/FarmingHelperPanel.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingHelperPanel.java
@@ -22,10 +22,10 @@ public class FarmingHelperPanel extends PluginPanel
 	private final FarmingHelperPlugin plugin;
     private final OverlayManager overlayManager;
     private final FarmingTeleportOverlay farmingTeleportOverlay;
-    private JButton herbButton;
-	private JButton treeButton;
-	private JButton fruitTreeButton;
-    private JLabel textLabel;
+
+    public StartStopJButton herbButton;
+    public StartStopJButton treeButton;
+    public StartStopJButton fruitTreeButton;
 
     public FarmingHelperPanel(FarmingHelperPlugin plugin, OverlayManager overlayManager, FarmingTeleportOverlay farmingTeleportOverlay, HerbRunItemAndLocation herbRunItemAndLocation, TreeRunItemAndLocation treeRunItemAndLocation, FruitTreeRunItemAndLocation fruitTreeRunItemAndLocation)
     {
@@ -84,7 +84,7 @@ public class FarmingHelperPanel extends PluginPanel
 //        constraints.gridwidth = 1;
 //        constraints.ipady = 10;
 
-        StartStopJButton herbButton = new StartStopJButton("Herb Run");
+        herbButton = new StartStopJButton("Herb Run");
 		herbButton.setFocusable(false);
         herbButton.addActionListener(new ActionListener() {
             @Override
@@ -104,7 +104,7 @@ public class FarmingHelperPanel extends PluginPanel
 //        farmRunButtonsPanel.add(herbButton, constraints);
         farmRunButtonsPanel.add(herbButton);
 
-        StartStopJButton treeButton = new StartStopJButton("Tree Run");
+        treeButton = new StartStopJButton("Tree Run");
         treeButton.setFocusable(false);
         treeButton.addActionListener(new ActionListener()
         {
@@ -125,7 +125,7 @@ public class FarmingHelperPanel extends PluginPanel
 //        farmRunButtonsPanel.add(treeButton, constraints);
         farmRunButtonsPanel.add(treeButton);
 
-        StartStopJButton fruitTreeButton = new StartStopJButton("Fruit Tree Run");
+        fruitTreeButton = new StartStopJButton("Fruit Tree Run");
         fruitTreeButton.setFocusable(false);
         fruitTreeButton.addActionListener(new ActionListener()
         {

--- a/src/main/java/com/farminghelper/speaax/FarmingHelperPlugin.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingHelperPlugin.java
@@ -359,7 +359,7 @@ public class FarmingHelperPlugin extends Plugin
 		isOverlayActive = false;
 		eventBus.register(this);
 
-		herbRunItemAndLocation.setupHerbLocations();
+		herbRunItemAndLocation.setupLocations();
 
 	}
 

--- a/src/main/java/com/farminghelper/speaax/FarmingHelperPlugin.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingHelperPlugin.java
@@ -173,7 +173,7 @@ public class FarmingHelperPlugin extends Plugin
 
 
 	private FarmingHelperPanel farmingHelperPanel;
-	private FarmingHelperPanel panel;
+	public FarmingHelperPanel panel;
 	private NavigationButton navButton;
 
 	@Inject
@@ -366,10 +366,6 @@ public class FarmingHelperPlugin extends Plugin
 		overlayManager.remove(farmingHelperOverlay);
 		overlayManager.remove(farmingTeleportOverlay);
 		overlayManager.remove(farmingHelperOverlayInfoBox);
-
-		panel.herbButton.setStartStopState(false);
-		panel.treeButton.setStartStopState(false);
-		panel.fruitTreeButton.setStartStopState(false);
 
 		eventBus.unregister(this);
 	}

--- a/src/main/java/com/farminghelper/speaax/FarmingHelperPlugin.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingHelperPlugin.java
@@ -331,7 +331,6 @@ public class FarmingHelperPlugin extends Plugin
 	@Override
 	protected void startUp()
 	{
-
 		herbRunItemAndLocation = new HerbRunItemAndLocation(config, client, this);
 		treeRunItemAndLocation = new TreeRunItemAndLocation(config, client, this);
 		fruitTreeRunItemAndLocation = new FruitTreeRunItemAndLocation(config, client, this);
@@ -352,24 +351,26 @@ public class FarmingHelperPlugin extends Plugin
 		overlayManager.add(farmingTeleportOverlay);
 		overlayManager.add(farmingHelperOverlayInfoBox);
 
-
-
-
 		// set overlay to inactive
 		isOverlayActive = false;
 		eventBus.register(this);
 
 		herbRunItemAndLocation.setupLocations();
-
 	}
 
 	@Override
 	protected void shutDown()
 	{
 		clientToolbar.removeNavigation(navButton);
+
 		overlayManager.remove(farmingHelperOverlay);
 		overlayManager.remove(farmingTeleportOverlay);
 		overlayManager.remove(farmingHelperOverlayInfoBox);
+
+		panel.herbButton.setStartStopState(false);
+		panel.treeButton.setStartStopState(false);
+		panel.fruitTreeButton.setStartStopState(false);
+
 		eventBus.unregister(this);
 	}
 }

--- a/src/main/java/com/farminghelper/speaax/FarmingHelperPlugin.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingHelperPlugin.java
@@ -341,7 +341,7 @@ public class FarmingHelperPlugin extends Plugin
 		final BufferedImage icon = ImageUtil.loadImageResource(getClass(), "/com/farminghelper/speaax/icon.png");
 
 		navButton = NavigationButton.builder()
-				.tooltip("Lazy Farming ")
+				.tooltip("Lazy Farming")
 				.icon(icon)
 				.priority(6)
 				.panel(panel)

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -1080,8 +1080,10 @@ public class FarmingTeleportOverlay extends Overlay {
         plugin.overlayManager.remove(farmingHelperOverlay);
         plugin.overlayManager.remove(farmingTeleportOverlay);
         plugin.overlayManager.remove(farmingHelperOverlayInfoBox);
+
         plugin.setOverlayActive(false);
         plugin.setTeleportOverlayActive(false);
+
         herbRunIndex = 0;
         currentTeleportCase = 1;
         subCase = 1;
@@ -1089,7 +1091,9 @@ public class FarmingTeleportOverlay extends Overlay {
         isAtDestination = false;
         farmLimps = false;
         flowerPatchDone = false;
+
         plugin.setItemsCollected(false);
+
         plugin.getFarmingTeleportOverlay().herbRun = false;
         plugin.getFarmingTeleportOverlay().treeRun = false;
         plugin.getFarmingTeleportOverlay().fruitTreeRun = false;
@@ -1098,6 +1102,9 @@ public class FarmingTeleportOverlay extends Overlay {
         herbRun = false;
         treeRun = false;
 
+        plugin.panel.herbButton.setStartStopState(false);
+        plugin.panel.treeButton.setStartStopState(false);
+        plugin.panel.fruitTreeButton.setStartStopState(false);
     }
 
     public Boolean herbRun = false;

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/FruitTreeRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/FruitTreeRunItemAndLocation.java
@@ -32,7 +32,7 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation {
     public Map<Integer, Integer> getAllItemRequirements(List<Location> locations) {
         Map<Integer, Integer> allRequirements = new HashMap<>();
 
-        setupFruitTreeLocations();
+        setupLocations();
 
         // Add other items and merge them with allRequirements
         for (Location location : locations) {
@@ -69,16 +69,29 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation {
         return allRequirements;
     }
 
-    public void setupFruitTreeLocations() {
-        // Clear the existing locations list
-        locations.clear();
+    public void setupLocations()
+    {
+        super.setupLocations();
+
+        setupBrimhavenLocations();
+        setupCatherbyLocations();
+        setupFarmingGuildLocation();
+        setupGnomeStrongholdLocation();
+        setupLletyaLocation();
+        setupTreeGnomeVillage();
+    }
+
+    private void setupBrimhavenLocations()
+    {
+        WorldPoint brimhavenFruitTreePatchPoint = new WorldPoint(2764, 3212, 0);
 
         brimhavenFruitTreeLocation = new Location(FarmingHelperConfig::enumFruitTreeBrimhavenTeleport, config, "Brimhaven", false);
+
         List<ItemRequirement> brimhavenFruitTreeTeleportItems = Arrays.asList(
                 new ItemRequirement(ItemID.COINS_995, 30),
                 new ItemRequirement(ItemID.LAW_RUNE, 2),
-                new ItemRequirement(ItemID.WATER_RUNE, 2));
-        WorldPoint brimhavenFruitTreePatchPoint = new WorldPoint(2764, 3212, 0);
+                new ItemRequirement(ItemID.WATER_RUNE, 2)
+        );
         Location.Teleport brimhavenFruitTreeTeleport = brimhavenFruitTreeLocation.new Teleport(
                 "Ardougne_teleport",
                 Location.TeleportCategory.SPELLBOOK,
@@ -89,13 +102,21 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation {
                 38,
                 10547,
                 brimhavenFruitTreePatchPoint,
-                brimhavenFruitTreeTeleportItems);
+                brimhavenFruitTreeTeleportItems
+        );
+
         brimhavenFruitTreeLocation.addTeleportOption(brimhavenFruitTreeTeleport);
+
         locations.add(brimhavenFruitTreeLocation);
+    }
+
+    private void setupCatherbyLocations()
+    {
+        WorldPoint cathebyFruitTreePatchPoint = new WorldPoint(2860, 3433, 0);
 
         catherbyFruitTreeLocation = new Location(FarmingHelperConfig::enumFruitTreeCatherbyTeleport, config, "Catherby", false);
+
         List<ItemRequirement> catherbyFruitTreeTeleportItems = getHouseTeleportItemRequirements();
-        WorldPoint cathebyFruitTreePatchPoint = new WorldPoint(2860, 3433, 0);
         Location.Teleport catherbyFruitTreeTeleport = catherbyFruitTreeLocation.new Teleport(
                 "Portal_nexus",
                 Location.TeleportCategory.PORTAL_NEXUS,
@@ -106,13 +127,21 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation {
                 13,
                 11061,
                 cathebyFruitTreePatchPoint,
-                catherbyFruitTreeTeleportItems);
+                catherbyFruitTreeTeleportItems
+        );
+
         catherbyFruitTreeLocation.addTeleportOption(catherbyFruitTreeTeleport);
+
         locations.add(catherbyFruitTreeLocation);
+    }
+
+    private void setupFarmingGuildLocation()
+    {
+        WorldPoint farmingGuildFruitTreePatchPoint = new WorldPoint(1243, 3759, 0);
 
         farmingGuildFruitTreeLocation = new Location(FarmingHelperConfig::enumFruitTreeFarmingGuildTeleport, config, "Farming Guild", false);
+
         List<ItemRequirement> farmingGuildFruitTreeTeleportItems = getHouseTeleportItemRequirements();
-        WorldPoint farmingGuildFruitTreePatchPoint = new WorldPoint(1243, 3759, 0);
         Location.Teleport farmingGuildFruitTreeTeleport = farmingGuildFruitTreeLocation.new Teleport(
                 "Jewellery_box",
                 Location.TeleportCategory.JEWELLERY_BOX,
@@ -123,14 +152,23 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation {
                 13,
                 4922,
                 farmingGuildFruitTreePatchPoint,
-                farmingGuildFruitTreeTeleportItems);
+                farmingGuildFruitTreeTeleportItems
+        );
+
         farmingGuildFruitTreeLocation.addTeleportOption(farmingGuildFruitTreeTeleport);
+
         locations.add(farmingGuildFruitTreeLocation);
+    }
+
+    private void setupGnomeStrongholdLocation()
+    {
+        WorldPoint gnomeStrongholdFruitTreePatchPoint = new WorldPoint(2475, 3446, 0);
 
         gnomeStrongholdFruitTreeLocation = new Location(FarmingHelperConfig::enumFruitTreeGnomeStrongholdTeleport, config, "Gnome Stronghold", false);
+
         List<ItemRequirement> gnomeStrongholdFruitTreeTeleportItems = Arrays.asList(
-                new ItemRequirement(ItemID.ROYAL_SEED_POD, 1));
-        WorldPoint gnomeStrongholdFruitTreePatchPoint = new WorldPoint(2475, 3446, 0);
+                new ItemRequirement(ItemID.ROYAL_SEED_POD, 1)
+        );
         Location.Teleport gnomeStrongholdFruitTreeTeleport = gnomeStrongholdFruitTreeLocation.new Teleport(
                 "Royal_seed_pod",
                 Location.TeleportCategory.ITEM,
@@ -141,14 +179,23 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation {
                 0,
                 9782,
                 gnomeStrongholdFruitTreePatchPoint,
-                gnomeStrongholdFruitTreeTeleportItems);
+                gnomeStrongholdFruitTreeTeleportItems
+        );
+
         gnomeStrongholdFruitTreeLocation.addTeleportOption(gnomeStrongholdFruitTreeTeleport);
+
         locations.add(gnomeStrongholdFruitTreeLocation);
+    }
+
+    private void setupLletyaLocation()
+    {
+        WorldPoint lletyaFruitTreePatchPoint = new WorldPoint(2346, 3162, 0);
 
         lletyaFruitTreeLocation = new Location(FarmingHelperConfig::enumFruitTreeLletyaTeleport, config, "Lletya", false);
+
         List<ItemRequirement> lletyaFruitTreeTeleportItems = Arrays.asList(
-                new ItemRequirement(ItemID.TELEPORT_CRYSTAL_1, 1));
-        WorldPoint lletyaFruitTreePatchPoint = new WorldPoint(2346, 3162, 0);
+                new ItemRequirement(ItemID.TELEPORT_CRYSTAL_1, 1)
+        );
         Location.Teleport lletyaFruitTreeTeleport = lletyaFruitTreeLocation.new Teleport(
                 "Teleport_crystal",
                 Location.TeleportCategory.ITEM,
@@ -159,14 +206,23 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation {
                 0,
                 9265,
                 lletyaFruitTreePatchPoint,
-                lletyaFruitTreeTeleportItems);
+                lletyaFruitTreeTeleportItems
+        );
+
         lletyaFruitTreeLocation.addTeleportOption(lletyaFruitTreeTeleport);
+
         locations.add(lletyaFruitTreeLocation);
+    }
+
+    private void setupTreeGnomeVillage()
+    {
+        WorldPoint treeGnomeVillageFruitTreePatchPoint = new WorldPoint(2490, 3180, 0);
 
         treeGnomeVillageFruitTreeLocation = new Location(FarmingHelperConfig::enumFruitTreeTreeGnomeVillageTeleport, config, "Tree Gnome Village", false);
+
         List<ItemRequirement> treeGnomeVillageFruitTreeTeleportItems = Arrays.asList(
-                new ItemRequirement(ItemID.ROYAL_SEED_POD, 1));
-        WorldPoint treeGnomeVillageFruitTreePatchPoint = new WorldPoint(2490, 3180, 0);
+                new ItemRequirement(ItemID.ROYAL_SEED_POD, 1)
+        );
         Location.Teleport treeGnomeVillageFruitTreeTeleport = treeGnomeVillageFruitTreeLocation.new Teleport(
                 "Royal_seed_pod",
                 Location.TeleportCategory.ITEM,
@@ -177,9 +233,11 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation {
                 0,
                 9782,
                 treeGnomeVillageFruitTreePatchPoint,
-                treeGnomeVillageFruitTreeTeleportItems);
-        treeGnomeVillageFruitTreeLocation.addTeleportOption(treeGnomeVillageFruitTreeTeleport);
-        locations.add(treeGnomeVillageFruitTreeLocation);
+                treeGnomeVillageFruitTreeTeleportItems
+        );
 
+        treeGnomeVillageFruitTreeLocation.addTeleportOption(treeGnomeVillageFruitTreeTeleport);
+        
+        locations.add(treeGnomeVillageFruitTreeLocation);
     }
 }

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/FruitTreeRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/FruitTreeRunItemAndLocation.java
@@ -10,7 +10,8 @@ import net.runelite.api.coords.WorldPoint;
 
 import java.util.*;
 
-public class FruitTreeRunItemAndLocation extends ItemAndLocation {
+public class FruitTreeRunItemAndLocation extends ItemAndLocation
+{
     public Location brimhavenFruitTreeLocation;
     public Location catherbyFruitTreeLocation;
     public Location farmingGuildFruitTreeLocation;
@@ -18,18 +19,26 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation {
     public Location lletyaFruitTreeLocation;
     public Location treeGnomeVillageFruitTreeLocation;
 
-    public FruitTreeRunItemAndLocation() {
+    public FruitTreeRunItemAndLocation()
+    {
     }
 
-    public FruitTreeRunItemAndLocation(FarmingHelperConfig config, Client client, FarmingHelperPlugin plugin) {
-        super(config, client, plugin);
+    public FruitTreeRunItemAndLocation(FarmingHelperConfig config, Client client, FarmingHelperPlugin plugin)
+    {
+        super(
+            config,
+            client,
+            plugin
+        );
     }
 
-    public Map<Integer, Integer> getFruitTreeItems() {
+    public Map<Integer, Integer> getFruitTreeItems()
+    {
         return getAllItemRequirements(locations);
     }
 
-    public Map<Integer, Integer> getAllItemRequirements(List<Location> locations) {
+    public Map<Integer, Integer> getAllItemRequirements(List<Location> locations)
+    {
         Map<Integer, Integer> allRequirements = new HashMap<>();
 
         setupLocations();
@@ -39,9 +48,20 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation {
             if (plugin.getFruitTreeLocationEnabled(location.getName())) {
                 //ItemID.GUAM_SEED is default for herb seeds, code later will allow for any seed to be used, just needed a placeholder ID
                 //allRequirements.merge(ItemID.GUAM_SEED, 1, Integer::sum);
-                allRequirements.merge(ItemID.APPLE_SAPLING, 1, Integer::sum);
-                allRequirements.merge(ItemID.COINS_995, 200, Integer::sum);
+                allRequirements.merge(
+                    ItemID.APPLE_SAPLING,
+                    1,
+                    Integer::sum
+                );
+
+                allRequirements.merge(
+                    ItemID.COINS_995,
+                    200,
+                    Integer::sum
+                );
+
                 Location.Teleport teleport = location.getSelectedTeleport();
+
                 Map<Integer, Integer> locationRequirements = teleport.getItemRequirements();
 
                 for (Map.Entry<Integer, Integer> entry : locationRequirements.entrySet()) {
@@ -49,21 +69,50 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation {
                     int quantity = entry.getValue();
 
                     if (itemId == ItemID.CONSTRUCT_CAPE || itemId == ItemID.CONSTRUCT_CAPET || itemId == ItemID.MAX_CAPE || itemId == ItemID.ROYAL_SEED_POD) {
-                        allRequirements.merge(itemId, quantity, (oldValue, newValue) -> Math.min(1, oldValue + newValue));
+                        allRequirements.merge(
+                            itemId,
+                            quantity,
+                            (oldValue, newValue) -> Math.min(
+                                1,
+                                oldValue + newValue
+                            )
+                        );
                     } else {
-                        allRequirements.merge(itemId, quantity, Integer::sum);
+                        allRequirements.merge(
+                            itemId,
+                            quantity,
+                            Integer::sum
+                        );
                     }
                 }
             }
         }
 
         //allRequirements.merge(ItemID.SEED_DIBBER, 1, Integer::sum);
-        allRequirements.merge(ItemID.SPADE, 1, Integer::sum);
-        allRequirements.merge(ItemID.BOTTOMLESS_COMPOST_BUCKET_22997, 1, Integer::sum);
-        allRequirements.merge(ItemID.MAGIC_SECATEURS, 1, Integer::sum);
+        allRequirements.merge(
+            ItemID.SPADE,
+            1,
+            Integer::sum
+        );
+
+        allRequirements.merge(
+            ItemID.BOTTOMLESS_COMPOST_BUCKET_22997,
+            1,
+            Integer::sum
+        );
+
+        allRequirements.merge(
+            ItemID.MAGIC_SECATEURS,
+            1,
+            Integer::sum
+        );
 
         if (config.generalRake()) {
-            allRequirements.merge(ItemID.RAKE, 1, Integer::sum);
+            allRequirements.merge(
+                ItemID.RAKE,
+                1,
+                Integer::sum
+            );
         }
 
         return allRequirements;
@@ -83,161 +132,209 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation {
 
     private void setupBrimhavenLocations()
     {
-        WorldPoint brimhavenFruitTreePatchPoint = new WorldPoint(2764, 3212, 0);
-
-        brimhavenFruitTreeLocation = new Location(FarmingHelperConfig::enumFruitTreeBrimhavenTeleport, config, "Brimhaven", false);
-
-        List<ItemRequirement> brimhavenFruitTreeTeleportItems = Arrays.asList(
-                new ItemRequirement(ItemID.COINS_995, 30),
-                new ItemRequirement(ItemID.LAW_RUNE, 2),
-                new ItemRequirement(ItemID.WATER_RUNE, 2)
-        );
-        Location.Teleport brimhavenFruitTreeTeleport = brimhavenFruitTreeLocation.new Teleport(
-                "Ardougne_teleport",
-                Location.TeleportCategory.SPELLBOOK,
-                "Teleport to Ardougne with Spellbook and run to Brimhaven.",
-                0,
-                "null",
-                218,
-                38,
-                10547,
-                brimhavenFruitTreePatchPoint,
-                brimhavenFruitTreeTeleportItems
+        WorldPoint brimhavenFruitTreePatchPoint = new WorldPoint(
+            2764,
+            3212,
+            0
         );
 
-        brimhavenFruitTreeLocation.addTeleportOption(brimhavenFruitTreeTeleport);
+        brimhavenFruitTreeLocation = new Location(
+            FarmingHelperConfig::enumFruitTreeBrimhavenTeleport,
+            config,
+            "Brimhaven",
+            false
+        );
+
+        brimhavenFruitTreeLocation.addTeleportOption(brimhavenFruitTreeLocation.new Teleport(
+            "Ardougne_teleport",
+            Location.TeleportCategory.SPELLBOOK,
+            "Teleport to Ardougne with Spellbook and run to Brimhaven.",
+            0,
+            "null",
+            218,
+            38,
+            10547,
+            brimhavenFruitTreePatchPoint,
+            Arrays.asList(
+                new ItemRequirement(
+                    ItemID.COINS_995,
+                    30
+                ),
+                new ItemRequirement(
+                    ItemID.LAW_RUNE,
+                    2
+                ),
+                new ItemRequirement(
+                    ItemID.WATER_RUNE,
+                    2
+                )
+            )
+        ));
 
         locations.add(brimhavenFruitTreeLocation);
     }
 
     private void setupCatherbyLocations()
     {
-        WorldPoint cathebyFruitTreePatchPoint = new WorldPoint(2860, 3433, 0);
-
-        catherbyFruitTreeLocation = new Location(FarmingHelperConfig::enumFruitTreeCatherbyTeleport, config, "Catherby", false);
-
-        List<ItemRequirement> catherbyFruitTreeTeleportItems = getHouseTeleportItemRequirements();
-        Location.Teleport catherbyFruitTreeTeleport = catherbyFruitTreeLocation.new Teleport(
-                "Portal_nexus",
-                Location.TeleportCategory.PORTAL_NEXUS,
-                "Teleport to Catherby with Portal nexus.",
-                0,
-                "null",
-                17,
-                13,
-                11061,
-                cathebyFruitTreePatchPoint,
-                catherbyFruitTreeTeleportItems
+        WorldPoint cathebyFruitTreePatchPoint = new WorldPoint(
+            2860,
+            3433,
+            0
         );
 
-        catherbyFruitTreeLocation.addTeleportOption(catherbyFruitTreeTeleport);
+        catherbyFruitTreeLocation = new Location(
+            FarmingHelperConfig::enumFruitTreeCatherbyTeleport,
+            config,
+            "Catherby",
+            false
+        );
+
+        catherbyFruitTreeLocation.addTeleportOption(catherbyFruitTreeLocation.new Teleport(
+            "Portal_nexus",
+            Location.TeleportCategory.PORTAL_NEXUS,
+            "Teleport to Catherby with Portal nexus.",
+            0,
+            "null",
+            17,
+            13,
+            11061,
+            cathebyFruitTreePatchPoint,
+            getHouseTeleportItemRequirements()
+        ));
 
         locations.add(catherbyFruitTreeLocation);
     }
 
     private void setupFarmingGuildLocation()
     {
-        WorldPoint farmingGuildFruitTreePatchPoint = new WorldPoint(1243, 3759, 0);
-
-        farmingGuildFruitTreeLocation = new Location(FarmingHelperConfig::enumFruitTreeFarmingGuildTeleport, config, "Farming Guild", false);
-
-        List<ItemRequirement> farmingGuildFruitTreeTeleportItems = getHouseTeleportItemRequirements();
-        Location.Teleport farmingGuildFruitTreeTeleport = farmingGuildFruitTreeLocation.new Teleport(
-                "Jewellery_box",
-                Location.TeleportCategory.JEWELLERY_BOX,
-                "Teleport to Farming Guild with Jewellery box.",
-                0,
-                "null",
-                17,
-                13,
-                4922,
-                farmingGuildFruitTreePatchPoint,
-                farmingGuildFruitTreeTeleportItems
+        WorldPoint farmingGuildFruitTreePatchPoint = new WorldPoint(
+            1243,
+            3759,
+            0
         );
 
-        farmingGuildFruitTreeLocation.addTeleportOption(farmingGuildFruitTreeTeleport);
+        farmingGuildFruitTreeLocation = new Location(
+            FarmingHelperConfig::enumFruitTreeFarmingGuildTeleport,
+            config,
+            "Farming Guild",
+            false
+        );
+
+        farmingGuildFruitTreeLocation.addTeleportOption(farmingGuildFruitTreeLocation.new Teleport(
+            "Jewellery_box",
+            Location.TeleportCategory.JEWELLERY_BOX,
+            "Teleport to Farming Guild with Jewellery box.",
+            0,
+            "null",
+            17,
+            13,
+            4922,
+            farmingGuildFruitTreePatchPoint,
+            getHouseTeleportItemRequirements()
+        ));
 
         locations.add(farmingGuildFruitTreeLocation);
     }
 
     private void setupGnomeStrongholdLocation()
     {
-        WorldPoint gnomeStrongholdFruitTreePatchPoint = new WorldPoint(2475, 3446, 0);
-
-        gnomeStrongholdFruitTreeLocation = new Location(FarmingHelperConfig::enumFruitTreeGnomeStrongholdTeleport, config, "Gnome Stronghold", false);
-
-        List<ItemRequirement> gnomeStrongholdFruitTreeTeleportItems = Arrays.asList(
-                new ItemRequirement(ItemID.ROYAL_SEED_POD, 1)
+        WorldPoint gnomeStrongholdFruitTreePatchPoint = new WorldPoint(
+            2475,
+            3446,
+            0
         );
-        Location.Teleport gnomeStrongholdFruitTreeTeleport = gnomeStrongholdFruitTreeLocation.new Teleport(
-                "Royal_seed_pod",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Gnome Stronghold with Royal seed pod.",
+
+        gnomeStrongholdFruitTreeLocation = new Location(
+            FarmingHelperConfig::enumFruitTreeGnomeStrongholdTeleport,
+            config,
+            "Gnome Stronghold",
+            false
+        );
+
+        gnomeStrongholdFruitTreeLocation.addTeleportOption(gnomeStrongholdFruitTreeLocation.new Teleport(
+            "Royal_seed_pod",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Gnome Stronghold with Royal seed pod.",
+            ItemID.ROYAL_SEED_POD,
+            "null",
+            0,
+            0,
+            9782,
+            gnomeStrongholdFruitTreePatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.ROYAL_SEED_POD,
-                "null",
-                0,
-                0,
-                9782,
-                gnomeStrongholdFruitTreePatchPoint,
-                gnomeStrongholdFruitTreeTeleportItems
-        );
-
-        gnomeStrongholdFruitTreeLocation.addTeleportOption(gnomeStrongholdFruitTreeTeleport);
+                1
+            ))
+        ));
 
         locations.add(gnomeStrongholdFruitTreeLocation);
     }
 
     private void setupLletyaLocation()
     {
-        WorldPoint lletyaFruitTreePatchPoint = new WorldPoint(2346, 3162, 0);
-
-        lletyaFruitTreeLocation = new Location(FarmingHelperConfig::enumFruitTreeLletyaTeleport, config, "Lletya", false);
-
-        List<ItemRequirement> lletyaFruitTreeTeleportItems = Arrays.asList(
-                new ItemRequirement(ItemID.TELEPORT_CRYSTAL_1, 1)
+        WorldPoint lletyaFruitTreePatchPoint = new WorldPoint(
+            2346,
+            3162,
+            0
         );
-        Location.Teleport lletyaFruitTreeTeleport = lletyaFruitTreeLocation.new Teleport(
-                "Teleport_crystal",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Lletya with Teleport crystal.",
+
+        lletyaFruitTreeLocation = new Location(
+            FarmingHelperConfig::enumFruitTreeLletyaTeleport,
+            config,
+            "Lletya",
+            false
+        );
+
+        lletyaFruitTreeLocation.addTeleportOption(lletyaFruitTreeLocation.new Teleport(
+            "Teleport_crystal",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Lletya with Teleport crystal.",
+            ItemID.TELEPORT_CRYSTAL_1,
+            "null",
+            0,
+            0,
+            9265,
+            lletyaFruitTreePatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.TELEPORT_CRYSTAL_1,
-                "null",
-                0,
-                0,
-                9265,
-                lletyaFruitTreePatchPoint,
-                lletyaFruitTreeTeleportItems
-        );
-
-        lletyaFruitTreeLocation.addTeleportOption(lletyaFruitTreeTeleport);
+                1
+            ))
+        ));
 
         locations.add(lletyaFruitTreeLocation);
     }
 
     private void setupTreeGnomeVillage()
     {
-        WorldPoint treeGnomeVillageFruitTreePatchPoint = new WorldPoint(2490, 3180, 0);
-
-        treeGnomeVillageFruitTreeLocation = new Location(FarmingHelperConfig::enumFruitTreeTreeGnomeVillageTeleport, config, "Tree Gnome Village", false);
-
-        List<ItemRequirement> treeGnomeVillageFruitTreeTeleportItems = Arrays.asList(
-                new ItemRequirement(ItemID.ROYAL_SEED_POD, 1)
+        WorldPoint treeGnomeVillageFruitTreePatchPoint = new WorldPoint(
+            2490,
+            3180,
+            0
         );
-        Location.Teleport treeGnomeVillageFruitTreeTeleport = treeGnomeVillageFruitTreeLocation.new Teleport(
-                "Royal_seed_pod",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Tree Gnome Village with Royal seed pod and use Spirit tree to Tree Gnome Village.",
+
+        treeGnomeVillageFruitTreeLocation = new Location(
+            FarmingHelperConfig::enumFruitTreeTreeGnomeVillageTeleport,
+            config,
+            "Tree Gnome Village",
+            false
+        );
+
+        treeGnomeVillageFruitTreeLocation.addTeleportOption(treeGnomeVillageFruitTreeLocation.new Teleport(
+            "Royal_seed_pod",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Tree Gnome Village with Royal seed pod and use Spirit tree to Tree Gnome Village.",
+            ItemID.ROYAL_SEED_POD,
+            "null",
+            0,
+            0,
+            9782,
+            treeGnomeVillageFruitTreePatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.ROYAL_SEED_POD,
-                "null",
-                0,
-                0,
-                9782,
-                treeGnomeVillageFruitTreePatchPoint,
-                treeGnomeVillageFruitTreeTeleportItems
-        );
+                1
+            ))
+        ));
 
-        treeGnomeVillageFruitTreeLocation.addTeleportOption(treeGnomeVillageFruitTreeTeleport);
-        
         locations.add(treeGnomeVillageFruitTreeLocation);
     }
 }

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/FruitTreeRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/FruitTreeRunItemAndLocation.java
@@ -10,12 +10,7 @@ import net.runelite.api.coords.WorldPoint;
 
 import java.util.*;
 
-public class FruitTreeRunItemAndLocation {
-    private FarmingHelperConfig config;
-
-    private Client client;
-    private FarmingHelperPlugin plugin;
-
+public class FruitTreeRunItemAndLocation extends ItemAndLocation {
     public Location brimhavenFruitTreeLocation;
     public Location catherbyFruitTreeLocation;
     public Location farmingGuildFruitTreeLocation;
@@ -23,60 +18,22 @@ public class FruitTreeRunItemAndLocation {
     public Location lletyaFruitTreeLocation;
     public Location treeGnomeVillageFruitTreeLocation;
 
-
-    public List<Location> locations = new ArrayList<>();
     public FruitTreeRunItemAndLocation() {
     }
 
     public FruitTreeRunItemAndLocation(FarmingHelperConfig config, Client client, FarmingHelperPlugin plugin) {
-        this.config = config;
-        this.client = client;
-        this.plugin = plugin;
+        super(config, client, plugin);
     }
 
     public Map<Integer, Integer> getFruitTreeItems() {
         return getAllItemRequirements(locations);
     }
 
-    public List<ItemRequirement> getHouseTeleportItemRequirements() {
-        FarmingHelperConfig.OptionEnumHouseTele selectedOption = config.enumConfigHouseTele();
-        List<ItemRequirement> itemRequirements = new ArrayList<>();
-
-        switch (selectedOption) {
-            case Law_air_earth_runes:
-                itemRequirements.add(new ItemRequirement(ItemID.AIR_RUNE, 1));
-                itemRequirements.add(new ItemRequirement(ItemID.EARTH_RUNE, 1));
-                itemRequirements.add(new ItemRequirement(ItemID.LAW_RUNE, 1));
-                break;
-                /*
-            case Law_dust_runes:
-                itemRequirements.add(new ItemRequirement(ItemID.DUST_RUNE, 1));
-                itemRequirements.add(new ItemRequirement(ItemID.LAW_RUNE, 1));
-                break;
-
-                 */
-            case Teleport_To_House:
-                itemRequirements.add(new ItemRequirement(ItemID.TELEPORT_TO_HOUSE, 1));
-                break;
-            case Construction_cape:
-                itemRequirements.add(new ItemRequirement(ItemID.CONSTRUCT_CAPE, 1));
-                break;
-            case Construction_cape_t:
-                itemRequirements.add(new ItemRequirement(ItemID.CONSTRUCT_CAPET, 1));
-                break;
-            case Max_cape:
-                itemRequirements.add(new ItemRequirement(ItemID.MAX_CAPE, 1));
-                break;
-            default:
-                throw new IllegalStateException("Unexpected value: " + selectedOption);
-        }
-
-        return itemRequirements;
-    }
-
     public Map<Integer, Integer> getAllItemRequirements(List<Location> locations) {
         Map<Integer, Integer> allRequirements = new HashMap<>();
+
         setupFruitTreeLocations();
+
         // Add other items and merge them with allRequirements
         for (Location location : locations) {
             if (plugin.getFruitTreeLocationEnabled(location.getName())) {
@@ -86,6 +43,7 @@ public class FruitTreeRunItemAndLocation {
                 allRequirements.merge(ItemID.COINS_995, 200, Integer::sum);
                 Location.Teleport teleport = location.getSelectedTeleport();
                 Map<Integer, Integer> locationRequirements = teleport.getItemRequirements();
+
                 for (Map.Entry<Integer, Integer> entry : locationRequirements.entrySet()) {
                     int itemId = entry.getKey();
                     int quantity = entry.getValue();
@@ -98,13 +56,19 @@ public class FruitTreeRunItemAndLocation {
                 }
             }
         }
+
         //allRequirements.merge(ItemID.SEED_DIBBER, 1, Integer::sum);
         allRequirements.merge(ItemID.SPADE, 1, Integer::sum);
         allRequirements.merge(ItemID.BOTTOMLESS_COMPOST_BUCKET_22997, 1, Integer::sum);
         allRequirements.merge(ItemID.MAGIC_SECATEURS, 1, Integer::sum);
-        if(config.generalRake()){allRequirements.merge(ItemID.RAKE, 1, Integer::sum);}
+
+        if (config.generalRake()) {
+            allRequirements.merge(ItemID.RAKE, 1, Integer::sum);
+        }
+
         return allRequirements;
     }
+
     public void setupFruitTreeLocations() {
         // Clear the existing locations list
         locations.clear();

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/FruitTreeRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/FruitTreeRunItemAndLocation.java
@@ -203,7 +203,7 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation
         );
 
         catherbyFruitTreeLocation.addTeleportOption(catherbyFruitTreeLocation.new Teleport(
-            "Portal_Nexus",
+            "Portal_Nexus_Catherby",
             Location.TeleportCategory.PORTAL_NEXUS,
             "Teleport to Catherby with Portal Nexus.",
             0,
@@ -211,6 +211,19 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation
             17,
             13,
             11061,
+            cathebyFruitTreePatchPoint,
+            getHouseTeleportItemRequirements()
+        ));
+
+        catherbyFruitTreeLocation.addTeleportOption(catherbyFruitTreeLocation.new Teleport(
+            "Portal_Nexus_Camelot",
+            Location.TeleportCategory.PORTAL_NEXUS,
+            "Teleport to Camelot with Portal Nexus.",
+            0,
+            "null",
+            17,
+            13,
+            11062,
             cathebyFruitTreePatchPoint,
             getHouseTeleportItemRequirements()
         ));

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/FruitTreeRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/FruitTreeRunItemAndLocation.java
@@ -146,9 +146,22 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation
         );
 
         brimhavenFruitTreeLocation.addTeleportOption(brimhavenFruitTreeLocation.new Teleport(
+            "Portal_Nexus",
+            Location.TeleportCategory.PORTAL_NEXUS,
+            "Teleport to Ardougne with Portal Nexus and take the boat to Brimhaven.",
+            0,
+            "null",
+            17,
+            13,
+            10547,
+            brimhavenFruitTreePatchPoint,
+            getHouseTeleportItemRequirements()
+        ));
+
+        brimhavenFruitTreeLocation.addTeleportOption(brimhavenFruitTreeLocation.new Teleport(
             "Ardougne_teleport",
             Location.TeleportCategory.SPELLBOOK,
-            "Teleport to Ardougne with Spellbook and run to Brimhaven.",
+            "Teleport to Ardougne with Spellbook and take the boat to Brimhaven.",
             0,
             "null",
             218,
@@ -190,9 +203,9 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation
         );
 
         catherbyFruitTreeLocation.addTeleportOption(catherbyFruitTreeLocation.new Teleport(
-            "Portal_nexus",
+            "Portal_Nexus",
             Location.TeleportCategory.PORTAL_NEXUS,
-            "Teleport to Catherby with Portal nexus.",
+            "Teleport to Catherby with Portal Nexus.",
             0,
             "null",
             17,

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/HerbRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/HerbRunItemAndLocation.java
@@ -10,7 +10,8 @@ import net.runelite.api.coords.WorldPoint;
 
 import java.util.*;
 
-public class HerbRunItemAndLocation extends ItemAndLocation {
+public class HerbRunItemAndLocation extends ItemAndLocation
+{
     public Location ardougneLocation;
     public Location catherbyLocation;
     public Location faladorLocation;
@@ -27,7 +28,11 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
 
     public HerbRunItemAndLocation(FarmingHelperConfig config, Client client, FarmingHelperPlugin plugin)
     {
-        super(config, client, plugin);
+        super(
+            config,
+            client,
+            plugin
+        );
     }
 
     public Map<Integer, Integer> getHerbItems()
@@ -45,13 +50,22 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
         for (Location location : locations) {
             if (plugin.getHerbLocationEnabled(location.getName())) {
                 //ItemID.GUAM_SEED is default for herb seeds, code later will allow for any seed to be used, just needed a placeholder ID
-                allRequirements.merge(ItemID.GUAM_SEED, 1, Integer::sum);
+                allRequirements.merge(
+                    ItemID.GUAM_SEED,
+                    1,
+                    Integer::sum
+                );
 
-                if (selectedCompostID() != -1 && selectedCompostID() != ItemID.BOTTOMLESS_COMPOST_BUCKET_22997) {
-                    allRequirements.merge(selectedCompostID(), 1, Integer::sum);
+                if (selectedCompostID() != - 1 && selectedCompostID() != ItemID.BOTTOMLESS_COMPOST_BUCKET_22997) {
+                    allRequirements.merge(
+                        selectedCompostID(),
+                        1,
+                        Integer::sum
+                    );
                 }
 
                 Location.Teleport teleport = location.getSelectedTeleport();
+
                 Map<Integer, Integer> locationRequirements = teleport.getItemRequirements();
 
                 for (Map.Entry<Integer, Integer> entry : locationRequirements.entrySet()) {
@@ -59,33 +73,73 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                     int quantity = entry.getValue();
 
                     if (itemId == ItemID.CONSTRUCT_CAPE || itemId == ItemID.CONSTRUCT_CAPET || itemId == ItemID.MAX_CAPE) {
-                        allRequirements.merge(itemId, quantity, (oldValue, newValue) -> Math.min(1, oldValue + newValue));
+                        allRequirements.merge(
+                            itemId,
+                            quantity,
+                            (oldValue, newValue) -> Math.min(
+                                1,
+                                oldValue + newValue
+                            )
+                        );
                     } else {
-                        allRequirements.merge(itemId, quantity, Integer::sum);
+                        allRequirements.merge(
+                            itemId,
+                            quantity,
+                            Integer::sum
+                        );
                     }
                 }
 
-                if(location.getFarmLimps() && config.generalLimpwurt()) {
-                    allRequirements.merge(ItemID.LIMPWURT_SEED, 1, Integer::sum);
+                if (location.getFarmLimps() && config.generalLimpwurt()) {
+                    allRequirements.merge(
+                        ItemID.LIMPWURT_SEED,
+                        1,
+                        Integer::sum
+                    );
 
-                    if (selectedCompostID() != -1 && selectedCompostID() != ItemID.BOTTOMLESS_COMPOST_BUCKET_22997) {
-                        allRequirements.merge(selectedCompostID(), 1, Integer::sum);
+                    if (selectedCompostID() != - 1 && selectedCompostID() != ItemID.BOTTOMLESS_COMPOST_BUCKET_22997) {
+                        allRequirements.merge(
+                            selectedCompostID(),
+                            1,
+                            Integer::sum
+                        );
                     }
                 }
             }
         }
 
-        allRequirements.merge(ItemID.SEED_DIBBER, 1, Integer::sum);
-        allRequirements.merge(ItemID.SPADE, 1, Integer::sum);
+        allRequirements.merge(
+            ItemID.SEED_DIBBER,
+            1,
+            Integer::sum
+        );
+
+        allRequirements.merge(
+            ItemID.SPADE,
+            1,
+            Integer::sum
+        );
 
         if (selectedCompostID() == ItemID.BOTTOMLESS_COMPOST_BUCKET_22997) {
-            allRequirements.merge(ItemID.BOTTOMLESS_COMPOST_BUCKET_22997, 1, Integer::sum);
+            allRequirements.merge(
+                ItemID.BOTTOMLESS_COMPOST_BUCKET_22997,
+                1,
+                Integer::sum
+            );
         }
 
-        allRequirements.merge(ItemID.MAGIC_SECATEURS, 1, Integer::sum);
+        allRequirements.merge(
+            ItemID.MAGIC_SECATEURS,
+            1,
+            Integer::sum
+        );
 
         if (config.generalRake()) {
-            allRequirements.merge(ItemID.RAKE, 1, Integer::sum);
+            allRequirements.merge(
+                ItemID.RAKE,
+                1,
+                Integer::sum
+            );
         }
 
         return allRequirements;
@@ -108,541 +162,598 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
 
     private void setupArdougneLocation()
     {
-        WorldPoint ardougneHerbPatchPoint = new WorldPoint(2670, 3374, 0);
-
-        ardougneLocation = new Location(FarmingHelperConfig::enumOptionEnumArdougneTeleport, config, "Ardougne", true);
-
-        List<ItemRequirement> ardougneTeleportItem = Arrays.asList(
-                new ItemRequirement(ItemID.LAW_RUNE, 2),
-                new ItemRequirement(ItemID.WATER_RUNE, 2)
-        );
-        Location.Teleport ardougneTeleport = ardougneLocation.new Teleport(
-                "Ardougne_teleport",
-                Location.TeleportCategory.SPELLBOOK,
-                "Teleport to Ardougne with standard spellbook, and run north.",
-                0,
-                "null",
-                218,
-                38,
-                10547,
-                ardougneHerbPatchPoint,
-                ardougneTeleportItem
+        WorldPoint ardougneHerbPatchPoint = new WorldPoint(
+            2670,
+            3374,
+            0
         );
 
-        List<ItemRequirement> ardougneTeleTabItem = Arrays.asList(
-                new ItemRequirement(ItemID.ARDOUGNE_TELEPORT, 1)
+        ardougneLocation = new Location(
+            FarmingHelperConfig::enumOptionEnumArdougneTeleport,
+            config,
+            "Ardougne",
+            true
         );
-        Location.Teleport ardougneTeleTab = ardougneLocation.new Teleport(
-                "Ardougne_Tele_Tab",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Ardougne with Ardougne tele tab, and run north.",
+
+        ardougneLocation.addTeleportOption(ardougneLocation.new Teleport(
+            "Ardougne_teleport",
+            Location.TeleportCategory.SPELLBOOK,
+            "Teleport to Ardougne with standard spellbook, and run north.",
+            0,
+            "null",
+            218,
+            38,
+            10547,
+            ardougneHerbPatchPoint,
+            Arrays.asList(
+                new ItemRequirement(
+                    ItemID.LAW_RUNE,
+                    2
+                ),
+                new ItemRequirement(
+                    ItemID.WATER_RUNE,
+                    2
+                )
+            )
+        ));
+
+        ardougneLocation.addTeleportOption(ardougneLocation.new Teleport(
+            "Ardougne_Tele_Tab",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Ardougne with Ardougne tele tab, and run north.",
+            ItemID.ARDOUGNE_TELEPORT,
+            "null",
+            0,
+            0,
+            10547,
+            ardougneHerbPatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.ARDOUGNE_TELEPORT,
-                "null",
-                0,
-                0,
-                10547,
-                ardougneHerbPatchPoint,
-                ardougneTeleTabItem
-        );
+                1
+            ))
+        ));
 
-        List<ItemRequirement> ardougneArdyCloak2Item = Arrays.asList(
-                new ItemRequirement(ItemID.ARDOUGNE_CLOAK_2, 1)
-        );
-        Location.Teleport ardougneArdyCloak2 = ardougneLocation.new Teleport(
-                "Ardy_Cloak_2",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Ardougne with Ardougne cloak.",
+        ardougneLocation.addTeleportOption(ardougneLocation.new Teleport(
+            "Ardy_Cloak_2",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Ardougne with Ardougne cloak.",
+            ItemID.ARDOUGNE_CLOAK_2,
+            "Farm Teleport",
+            0,
+            0,
+            10548,
+            ardougneHerbPatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.ARDOUGNE_CLOAK_2,
-                "Farm Teleport",
-                0,
-                0,
-                10548,
-                ardougneHerbPatchPoint,
-                ardougneArdyCloak2Item
-        );
+                1
+            ))
+        ));
 
-        List<ItemRequirement> ardougneArdyCloak3Item = Arrays.asList(
-                new ItemRequirement(ItemID.ARDOUGNE_CLOAK_3, 1)
-        );
-        Location.Teleport ardougneArdyCloak3 = ardougneLocation.new Teleport(
-                "Ardy_Cloak_3",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Ardougne with Ardougne cloak.",
+        ardougneLocation.addTeleportOption(ardougneLocation.new Teleport(
+            "Ardy_Cloak_3",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Ardougne with Ardougne cloak.",
+            ItemID.ARDOUGNE_CLOAK_3,
+            "Farm Teleport",
+            0,
+            0,
+            10548,
+            ardougneHerbPatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.ARDOUGNE_CLOAK_3,
-                "Farm Teleport",
-                0,
-                0,
-                10548,
-                ardougneHerbPatchPoint,
-                ardougneArdyCloak3Item
-        );
+                1
+            ))
+        ));
 
-        List<ItemRequirement> ardougneArdyCloak4Item = Arrays.asList(
-                new ItemRequirement(ItemID.ARDOUGNE_CLOAK_4, 1)
-        );
-        Location.Teleport ardougneArdyCloak4 = ardougneLocation.new Teleport(
-                "Ardy_Cloak_4",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Ardougne with Ardougne cloak.",
+        ardougneLocation.addTeleportOption(ardougneLocation.new Teleport(
+            "Ardy_Cloak_4",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Ardougne with Ardougne cloak.",
+            ItemID.ARDOUGNE_CLOAK_4,
+            "Farm Teleport",
+            0,
+            0,
+            10548,
+            ardougneHerbPatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.ARDOUGNE_CLOAK_4,
-                "Farm Teleport",
-                0,
-                0,
-                10548,
-                ardougneHerbPatchPoint,
-                ardougneArdyCloak4Item
-        );
+                1
+            ))
+        ));
 
-        List<ItemRequirement> ardougneSkillsNecklaceItem = Arrays.asList(
-                new ItemRequirement(ItemID.SKILLS_NECKLACE1, 1)
-        );
-        Location.Teleport ardougneSkillsNecklace = ardougneLocation.new Teleport(
-                "Skills_Necklace",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Fishing guild with Skills necklace, and run east.",
+        ardougneLocation.addTeleportOption(ardougneLocation.new Teleport(
+            "Skills_Necklace",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Fishing guild with Skills necklace, and run east.",
+            ItemID.SKILLS_NECKLACE1,
+            "null",
+            0,
+            0,
+            10292,
+            ardougneHerbPatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.SKILLS_NECKLACE1,
-                "null",
-                0,
-                0,
-                10292,
-                ardougneHerbPatchPoint,
-                ardougneSkillsNecklaceItem
-        );
-
-        ardougneLocation.addTeleportOption(ardougneTeleport);
-        ardougneLocation.addTeleportOption(ardougneTeleTab);
-        ardougneLocation.addTeleportOption(ardougneArdyCloak2);
-        ardougneLocation.addTeleportOption(ardougneArdyCloak3);
-        ardougneLocation.addTeleportOption(ardougneArdyCloak4);
-        ardougneLocation.addTeleportOption(ardougneSkillsNecklace);
+                1
+            ))
+        ));
 
         locations.add(ardougneLocation);
     }
 
     private void setupCatherbyLocation()
     {
-        WorldPoint catherbyHerbPatchPoint = new WorldPoint(2813, 3463, 0);
-
-        catherbyLocation = new Location(FarmingHelperConfig::enumOptionEnumCatherbyTeleport, config, "Catherby", true);
-
-        List<ItemRequirement> catherbyPortalNexusItems = getHouseTeleportItemRequirements();
-        Location.Teleport catherbyPortalNexus = catherbyLocation.new Teleport(
-                "Portal_nexus",
-                Location.TeleportCategory.PORTAL_NEXUS,
-                "Teleport to Catherby with Portal nexus.",
-                0,
-                "null",
-                17,
-                13,
-                11061,
-                catherbyHerbPatchPoint,
-                catherbyPortalNexusItems
+        WorldPoint catherbyHerbPatchPoint = new WorldPoint(
+            2813,
+            3463,
+            0
         );
 
-        List<ItemRequirement> catherbyCamelotTeleportItems = Arrays.asList(
-                new ItemRequirement(ItemID.AIR_RUNE, 5),
-                new ItemRequirement(ItemID.LAW_RUNE, 1)
-        );
-        Location.Teleport catherbyCamelotTeleport = catherbyLocation.new Teleport(
-                "Camelot_Teleport",
-                Location.TeleportCategory.SPELLBOOK,
-                "Teleport to Camelot using the standard spellbook, and run east.(If you have configured the teleport to seers you need to right click and teleport to Camelot)",
-                0,
-                "null",
-                218,
-                32,
-                11062,
-                catherbyHerbPatchPoint,
-                catherbyCamelotTeleportItems
+        catherbyLocation = new Location(
+            FarmingHelperConfig::enumOptionEnumCatherbyTeleport,
+            config,
+            "Catherby",
+            true
         );
 
-        List<ItemRequirement> catherbyCamelotTeleTabItems = Arrays.asList(
-                new ItemRequirement(ItemID.CAMELOT_TELEPORT, 1)
-        );
-        Location.Teleport catherbyCamelotTeleTab = catherbyLocation.new Teleport(
-                "Camelot_Tele_Tab",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Camelot using a Camelot tele tab, and run east.(If you have configured the teleport to seers you need to right click and teleport to Camelot)",
+        catherbyLocation.addTeleportOption(catherbyLocation.new Teleport(
+            "Portal_nexus",
+            Location.TeleportCategory.PORTAL_NEXUS,
+            "Teleport to Catherby with Portal nexus.",
+            0,
+            "null",
+            17,
+            13,
+            11061,
+            catherbyHerbPatchPoint,
+            getHouseTeleportItemRequirements()
+        ));
+
+        catherbyLocation.addTeleportOption(catherbyLocation.new Teleport(
+            "Camelot_Teleport",
+            Location.TeleportCategory.SPELLBOOK,
+            "Teleport to Camelot using the standard spellbook, and run east. (If you have configured the teleport to seers you need to right click and teleport to Camelot)",
+            0,
+            "null",
+            218,
+            32,
+            11062,
+            catherbyHerbPatchPoint,
+            Arrays.asList(
+                new ItemRequirement(
+                    ItemID.AIR_RUNE,
+                    5
+                ),
+                new ItemRequirement(
+                    ItemID.LAW_RUNE,
+                    1
+                )
+            )
+        ));
+
+        catherbyLocation.addTeleportOption(catherbyLocation.new Teleport(
+            "Camelot_Tele_Tab",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Camelot using a Camelot tele tab, and run east.(If you have configured the teleport to seers you need to right click and teleport to Camelot)",
+            ItemID.CAMELOT_TELEPORT,
+            "null",
+            0,
+            0,
+            11062,
+            catherbyHerbPatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.CAMELOT_TELEPORT,
-                "null",
-                0,
-                0,
-                11062,
-                catherbyHerbPatchPoint,
-                catherbyCamelotTeleTabItems
-        );
+                1
+            ))
+        ));
 
-        List<ItemRequirement> catherbyTeleTabItems = Arrays.asList(
-                new ItemRequirement(ItemID.CATHERBY_TELEPORT, 1)
-        );
-        Location.Teleport catherbyTeleTab = catherbyLocation.new Teleport(
-                "Catherby_Tele_Tab",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Catherby using Catherby teleport tab.",
+        catherbyLocation.addTeleportOption(catherbyLocation.new Teleport(
+            "Catherby_Tele_Tab",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Catherby using Catherby teleport tab.",
+            ItemID.CATHERBY_TELEPORT,
+            "null",
+            0,
+            0,
+            11061,
+            catherbyHerbPatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.CATHERBY_TELEPORT,
-                "null",
-                0,
-                0,
-                11061,
-                catherbyHerbPatchPoint,
-                catherbyTeleTabItems
-        );
-
-        catherbyLocation.addTeleportOption(catherbyPortalNexus);
-        catherbyLocation.addTeleportOption(catherbyCamelotTeleport);
-        catherbyLocation.addTeleportOption(catherbyCamelotTeleTab);
-        catherbyLocation.addTeleportOption(catherbyTeleTab);
+                1
+            ))
+        ));
 
         locations.add(catherbyLocation);
     }
 
     private void setupFaladorLocation()
     {
-        WorldPoint faladorHerbPatchPoint = new WorldPoint(3058, 3307, 0);
-
-        faladorLocation = new Location(FarmingHelperConfig::enumOptionEnumFaladorTeleport, config, "Falador", true);
-
-        List<ItemRequirement> faladorExplorersRing2Item = Arrays.asList(
-                new ItemRequirement(ItemID.EXPLORERS_RING_2, 1)
+        WorldPoint faladorHerbPatchPoint = new WorldPoint(
+            3058,
+            3307,
+            0
         );
-        Location.Teleport faladorExplorersRing2 = faladorLocation.new Teleport(
-                "Explorers_ring_2",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Falador with Explorers ring.",
+
+        faladorLocation = new Location(
+            FarmingHelperConfig::enumOptionEnumFaladorTeleport,
+            config,
+            "Falador",
+            true
+        );
+
+        faladorLocation.addTeleportOption(faladorLocation.new Teleport(
+            "Explorers_ring_2",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Falador with Explorers ring.",
+            ItemID.EXPLORERS_RING_2,
+            "Teleport",
+            0,
+            0,
+            12083,
+            faladorHerbPatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.EXPLORERS_RING_2,
-                "Teleport",
-                0,
-                0,
-                12083,
-                faladorHerbPatchPoint,
-                faladorExplorersRing2Item
-        );
+                1
+            ))
+        ));
 
-        List<ItemRequirement> faladorExplorersRing3Item = Arrays.asList(
-                new ItemRequirement(ItemID.EXPLORERS_RING_3, 1)
-        );
-        Location.Teleport faladorExplorersRing3 = faladorLocation.new Teleport(
-                "Explorers_ring_3",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Falador with Explorers ring.",
+        faladorLocation.addTeleportOption(faladorLocation.new Teleport(
+            "Explorers_ring_3",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Falador with Explorers ring.",
+            ItemID.EXPLORERS_RING_3,
+            "Teleport",
+            0,
+            0,
+            12083,
+            faladorHerbPatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.EXPLORERS_RING_3,
-                "Teleport",
-                0,
-                0,
-                12083,
-                faladorHerbPatchPoint,
-                faladorExplorersRing3Item
-        );
+                1
+            ))
+        ));
 
-        List<ItemRequirement> faladorExplorersRing4Item = Arrays.asList(
-                new ItemRequirement(ItemID.EXPLORERS_RING_4, 1)
-        );
-        Location.Teleport faladorExplorersRing4 = faladorLocation.new Teleport(
-                "Explorers_ring_4",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Falador with Explorers ring.",
+        faladorLocation.addTeleportOption(faladorLocation.new Teleport(
+            "Explorers_ring_4",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Falador with Explorers ring.",
+            ItemID.EXPLORERS_RING_4,
+            "Teleport",
+            0,
+            0,
+            12083,
+            faladorHerbPatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.EXPLORERS_RING_4,
-                "Teleport",
-                0,
-                0,
-                12083,
-                faladorHerbPatchPoint,
-                faladorExplorersRing4Item
-        );
+                1
+            ))
+        ));
 
-        List<ItemRequirement> faladorTeleportItem = Arrays.asList(
-                new ItemRequirement(ItemID.AIR_RUNE, 3),
-                new ItemRequirement(ItemID.LAW_RUNE, 1),
-                new ItemRequirement(ItemID.WATER_RUNE, 1)
-        );
-        Location.Teleport faladorTeleport = faladorLocation.new Teleport(
-                "Falador_Teleport",
-                Location.TeleportCategory.SPELLBOOK,
-                "Teleport to Falador with standard spellbook, and run south-east.",
-                0,
-                "null",
-                218,
-                27,
-                11828,
-                faladorHerbPatchPoint,
-                faladorTeleportItem
-        );
+        faladorLocation.addTeleportOption(faladorLocation.new Teleport(
+            "Falador_Teleport",
+            Location.TeleportCategory.SPELLBOOK,
+            "Teleport to Falador with standard spellbook, and run south-east.",
+            0,
+            "null",
+            218,
+            27,
+            11828,
+            faladorHerbPatchPoint,
+            Arrays.asList(
+                new ItemRequirement(
+                    ItemID.AIR_RUNE,
+                    3
+                ),
+                new ItemRequirement(
+                    ItemID.LAW_RUNE,
+                    1
+                ),
+                new ItemRequirement(
+                    ItemID.WATER_RUNE,
+                    1
+                )
+            )
+        ));
 
-        List<ItemRequirement> faladorTeleTabItem = Arrays.asList(
-                new ItemRequirement(ItemID.FALADOR_TELEPORT, 1)
-        );
-        Location.Teleport faladorTeleTab = faladorLocation.new Teleport(
-                "Falador_Tele_Tab",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Falador with Falador Tele Tab, and run south-east.",
+        faladorLocation.addTeleportOption(faladorLocation.new Teleport(
+            "Falador_Tele_Tab",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Falador with Falador Tele Tab, and run south-east.",
+            ItemID.FALADOR_TELEPORT,
+            "null",
+            0,
+            0,
+            11828,
+            faladorHerbPatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.FALADOR_TELEPORT,
-                "null",
-                0,
-                0,
-                11828,
-                faladorHerbPatchPoint,
-                faladorTeleTabItem
-        );
+                1
+            ))
+        ));
 
-        List<ItemRequirement> faladorDraynorManorTeleTabItem = Arrays.asList(
-                new ItemRequirement(ItemID.DRAYNOR_MANOR_TELEPORT, 1)
-        );
-        Location.Teleport faladorDraynorManorTeleTab = faladorLocation.new Teleport(
-                "Draynor_Tele_Tab",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Draynor Manor with Draynor Manor Tele Tab, and run south-west.",
+        faladorLocation.addTeleportOption(faladorLocation.new Teleport(
+            "Draynor_Tele_Tab",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Draynor Manor with Draynor Manor Tele Tab, and run south-west.",
+            ItemID.DRAYNOR_MANOR_TELEPORT,
+            "null",
+            0,
+            0,
+            12340,
+            faladorHerbPatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.DRAYNOR_MANOR_TELEPORT,
-                "null",
-                0,
-                0,
-                12340,
-                faladorHerbPatchPoint,
-                faladorDraynorManorTeleTabItem
-        );
-
-        faladorLocation.addTeleportOption(faladorExplorersRing2);
-        faladorLocation.addTeleportOption(faladorExplorersRing3);
-        faladorLocation.addTeleportOption(faladorExplorersRing4);
-        faladorLocation.addTeleportOption(faladorTeleport);
-        faladorLocation.addTeleportOption(faladorTeleTab);
-        faladorLocation.addTeleportOption(faladorDraynorManorTeleTab);
+                1
+            ))
+        ));
 
         locations.add(faladorLocation);
     }
 
     private void setupFarmingGuildLocation()
     {
-        WorldPoint farmingGuildHerbPatchPoint = new WorldPoint(1238, 3726, 0);
-
-        farmingGuildLocation = new Location(FarmingHelperConfig::enumOptionEnumFarmingGuildTeleport, config, "Farming Guild", true);
-
-        List<ItemRequirement> farmingGuildJewelleryBoxItems = getHouseTeleportItemRequirements();
-        Location.Teleport farmingGuildJewelleryBox = farmingGuildLocation.new Teleport(
-                "Jewellery_box",
-                Location.TeleportCategory.JEWELLERY_BOX,
-                "Teleport to Farming guild with Jewellery box.",
-                29155,
-                "null",
-                0,
-                0,
-                4922,
-                farmingGuildHerbPatchPoint,
-                farmingGuildJewelleryBoxItems
+        WorldPoint farmingGuildHerbPatchPoint = new WorldPoint(
+            1238,
+            3726,
+            0
         );
 
-        List<ItemRequirement> farmingGuildSkillsNecklaceItems = Arrays.asList(
-                new ItemRequirement(ItemID.SKILLS_NECKLACE1, 1)
+        farmingGuildLocation = new Location(
+            FarmingHelperConfig::enumOptionEnumFarmingGuildTeleport,
+            config,
+            "Farming Guild",
+            true
         );
-        Location.Teleport farmingGuildSkillsNecklace = farmingGuildLocation.new Teleport(
-                "Skills_Necklace",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Farming guild using Skills necklace.",
+
+        farmingGuildLocation.addTeleportOption(farmingGuildLocation.new Teleport(
+            "Jewellery_box",
+            Location.TeleportCategory.JEWELLERY_BOX,
+            "Teleport to Farming guild with Jewellery box.",
+            29155,
+            "null",
+            0,
+            0,
+            4922,
+            farmingGuildHerbPatchPoint,
+            getHouseTeleportItemRequirements()
+        ));
+
+        farmingGuildLocation.addTeleportOption(farmingGuildLocation.new Teleport(
+            "Skills_Necklace",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Farming guild using Skills necklace.",
+            ItemID.SKILLS_NECKLACE1,
+            "null",
+            0,
+            0,
+            4922,
+            farmingGuildHerbPatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.SKILLS_NECKLACE1,
-                "null",
-                0,
-                0,
-                4922,
-                farmingGuildHerbPatchPoint,
-                farmingGuildSkillsNecklaceItems
-        );
-
-        farmingGuildLocation.addTeleportOption(farmingGuildJewelleryBox);
-        farmingGuildLocation.addTeleportOption(farmingGuildSkillsNecklace);
+                1
+            ))
+        ));
 
         locations.add(farmingGuildLocation);
     }
 
     private void setupHarmonyLocation()
     {
-        WorldPoint harmonyHerbPatchPoint = new WorldPoint(3789, 2837, 0);
-
-        harmonyLocation = new Location(FarmingHelperConfig::enumOptionEnumHarmonyTeleport, config, "Harmony Island", false);
-
-        List<ItemRequirement> harmonyPortalNexusItems = getHouseTeleportItemRequirements();
-        Location.Teleport harmonyPortalNexus = harmonyLocation.new Teleport(
-                "Portal_Nexus",
-                Location.TeleportCategory.PORTAL_NEXUS,
-                "Teleport to Harmony with Portal Nexus.",
-                0,
-                "null",
-                17,
-                13,
-                15148,
-                harmonyHerbPatchPoint,
-                harmonyPortalNexusItems
+        WorldPoint harmonyHerbPatchPoint = new WorldPoint(
+            3789,
+            2837,
+            0
         );
 
-        List<ItemRequirement> harmonyTeleTabItems = Arrays.asList(
-                new ItemRequirement(ItemID.HARMONY_ISLAND_TELEPORT, 1)
+        harmonyLocation = new Location(
+            FarmingHelperConfig::enumOptionEnumHarmonyTeleport,
+            config,
+            "Harmony Island",
+            false
         );
-        Location.Teleport harmonyTeleTab = harmonyLocation.new Teleport(
-                "Harmony_Tele_Tab",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Harmony with Harmony Tele Tab.",
+
+        harmonyLocation.addTeleportOption(harmonyLocation.new Teleport(
+            "Portal_Nexus",
+            Location.TeleportCategory.PORTAL_NEXUS,
+            "Teleport to Harmony with Portal Nexus.",
+            0,
+            "null",
+            17,
+            13,
+            15148,
+            harmonyHerbPatchPoint,
+            getHouseTeleportItemRequirements()
+        ));
+
+        harmonyLocation.addTeleportOption(harmonyLocation.new Teleport(
+            "Harmony_Tele_Tab",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Harmony with Harmony Tele Tab.",
+            ItemID.HARMONY_ISLAND_TELEPORT,
+            "null",
+            0,
+            0,
+            15148,
+            harmonyHerbPatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.HARMONY_ISLAND_TELEPORT,
-                "null",
-                0,
-                0,
-                15148,
-                harmonyHerbPatchPoint,
-                harmonyTeleTabItems
-        );
-
-        harmonyLocation.addTeleportOption(harmonyPortalNexus);
-        harmonyLocation.addTeleportOption(harmonyTeleTab);
+                1
+            ))
+        ));
 
         locations.add(harmonyLocation);
     }
 
     private void setupKourendLocation()
     {
-        WorldPoint kourendHerbPatchPoint = new WorldPoint(1738, 3550, 0);
-
-        kourendLocation = new Location(FarmingHelperConfig::enumOptionEnumKourendTeleport, config, "Kourend", true);
-
-        List<ItemRequirement> kourendXericsTalismanItems = Arrays.asList(
-                new ItemRequirement(ItemID.XERICS_TALISMAN, 1)
+        WorldPoint kourendHerbPatchPoint = new WorldPoint(
+            1738,
+            3550,
+            0
         );
-        Location.Teleport kourendXericsTalisman = kourendLocation.new Teleport(
-                "Xerics_Talisman",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Kourend with Xeric's Talisman.",
+
+        kourendLocation = new Location(
+            FarmingHelperConfig::enumOptionEnumKourendTeleport,
+            config,
+            "Kourend",
+            true
+        );
+
+        kourendLocation.addTeleportOption(kourendLocation.new Teleport(
+            "Xerics_Talisman",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Kourend with Xeric's Talisman.",
+            ItemID.XERICS_TALISMAN,
+            "Rub",
+            187,
+            3,
+            6967,
+            kourendHerbPatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.XERICS_TALISMAN,
-                "Rub",
-                187,
-                3,
-                6967,
-                kourendHerbPatchPoint,
-                kourendXericsTalismanItems
-        );
+                1
+            ))
+        ));
 
-        List<ItemRequirement> kourendMountedXericsItems = getHouseTeleportItemRequirements();
-        Location.Teleport kourendMountedXerics = kourendLocation.new Teleport(
-                "Mounted_Xerics",
-                Location.TeleportCategory.MOUNTED_XERICS,
-                "Teleport to Kourend with Xeric's Talisman in PoH.",
-                0,
-                "null",
-                187,
-                3,
-                6967,
-                kourendHerbPatchPoint,
-                kourendMountedXericsItems
-        );
-
-        kourendLocation.addTeleportOption(kourendXericsTalisman);
-        kourendLocation.addTeleportOption(kourendMountedXerics);
+        kourendLocation.addTeleportOption(kourendLocation.new Teleport(
+            "Mounted_Xerics",
+            Location.TeleportCategory.MOUNTED_XERICS,
+            "Teleport to Kourend with Xeric's Talisman in PoH.",
+            0,
+            "null",
+            187,
+            3,
+            6967,
+            kourendHerbPatchPoint,
+            getHouseTeleportItemRequirements()
+        ));
 
         locations.add(kourendLocation);
     }
 
     private void setupMorytaniaLocation()
     {
-        WorldPoint morytaniaHerbPatchPoint = new WorldPoint(3601, 3525, 0);
-
-        morytaniaLocation = new Location(FarmingHelperConfig::enumOptionEnumMorytaniaTeleport, config, "Morytania", true);
-
-        List<ItemRequirement> morytaniaEctophialItems = Arrays.asList(
-                new ItemRequirement(ItemID.ECTOPHIAL, 1)
+        WorldPoint morytaniaHerbPatchPoint = new WorldPoint(
+            3601,
+            3525,
+            0
         );
-        Location.Teleport morytaniaEctophial = morytaniaLocation.new Teleport(
-                "Ectophial",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Morytania with Ectophial.",
+
+        morytaniaLocation = new Location(
+            FarmingHelperConfig::enumOptionEnumMorytaniaTeleport,
+            config,
+            "Morytania",
+            true
+        );
+
+        morytaniaLocation.addTeleportOption(morytaniaLocation.new Teleport(
+            "Ectophial",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Morytania with Ectophial.",
+            ItemID.ECTOPHIAL,
+            "null",
+            0,
+            0,
+            14647,
+            morytaniaHerbPatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.ECTOPHIAL,
-                "null",
-                0,
-                0,
-                14647,
-                morytaniaHerbPatchPoint,
-                morytaniaEctophialItems
-        );
-
-        morytaniaLocation.addTeleportOption(morytaniaEctophial);
+                1
+            ))
+        ));
 
         locations.add(morytaniaLocation);
     }
 
     private void setupTrollStrongholdLocation()
     {
-        WorldPoint trollStrongholhHerbPatchPoint = new WorldPoint(2824, 3696, 0);
-
-        trollStrongholdLocation = new Location(FarmingHelperConfig::enumOptionEnumTrollStrongholdTeleport, config, "Troll Stronghold", false);
-
-        List<ItemRequirement> tsStonyBasaltItems = Arrays.asList(
-                new ItemRequirement(ItemID.STONY_BASALT, 1)
+        WorldPoint trollStrongholdHerbPatchPoint = new WorldPoint(
+            2824,
+            3696,
+            0
         );
-        Location.Teleport tsStonyBasalt = trollStrongholdLocation.new Teleport(
-                "Stony_Basalt",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Troll Stronghold with Stony Basalt.",
+
+        trollStrongholdLocation = new Location(
+            FarmingHelperConfig::enumOptionEnumTrollStrongholdTeleport,
+            config,
+            "Troll Stronghold",
+            false
+        );
+
+        trollStrongholdLocation.addTeleportOption(trollStrongholdLocation.new Teleport(
+            "Stony_Basalt",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Troll Stronghold with Stony Basalt.",
+            ItemID.STONY_BASALT,
+            "null",
+            0,
+            0,
+            11321,
+            trollStrongholdHerbPatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.STONY_BASALT,
-                "null",
-                0,
-                0,
-                11321,
-                trollStrongholhHerbPatchPoint,
-                tsStonyBasaltItems
-        );
+                1
+            ))
+        ));
 
-        List<ItemRequirement> tsPortalNexusItems = getHouseTeleportItemRequirements();
-        Location.Teleport tsPortalNexus = trollStrongholdLocation.new Teleport(
-                "Portal_Nexus",
-                Location.TeleportCategory.PORTAL_NEXUS,
-                "Teleport to Troll Stronghold with Portal Nexus.",
-                0,
-                "null",
-                17,
-                13,
-                11321,
-                trollStrongholhHerbPatchPoint,
-                tsPortalNexusItems
-        );
-
-        trollStrongholdLocation.addTeleportOption(tsStonyBasalt);
-        trollStrongholdLocation.addTeleportOption(tsPortalNexus);
+        trollStrongholdLocation.addTeleportOption(trollStrongholdLocation.new Teleport(
+            "Portal_Nexus",
+            Location.TeleportCategory.PORTAL_NEXUS,
+            "Teleport to Troll Stronghold with Portal Nexus.",
+            0,
+            "null",
+            17,
+            13,
+            11321,
+            trollStrongholdHerbPatchPoint,
+            getHouseTeleportItemRequirements()
+        ));
 
         locations.add(trollStrongholdLocation);
     }
 
     private void setupWeissLocation()
     {
-        WorldPoint weissHerbPatchPoint = new WorldPoint(2847, 3931, 0);
-
-        weissLocation = new Location(FarmingHelperConfig::enumOptionEnumWeissTeleport, config, "Weiss", false);
-
-        List<ItemRequirement> weissIcyBasaltItems = Arrays.asList(
-                new ItemRequirement(ItemID.ICY_BASALT, 1)
+        WorldPoint weissHerbPatchPoint = new WorldPoint(
+            2847,
+            3931,
+            0
         );
-        Location.Teleport weissIcyBasalt = weissLocation.new Teleport(
-                "Icy_Basalt",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Weiss with Icy Basalt.",
+
+        weissLocation = new Location(
+            FarmingHelperConfig::enumOptionEnumWeissTeleport,
+            config,
+            "Weiss",
+            false
+        );
+
+        weissLocation.addTeleportOption(weissLocation.new Teleport(
+            "Icy_Basalt",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Weiss with Icy Basalt.",
+            ItemID.ICY_BASALT,
+            "null",
+            0,
+            0,
+            11325,
+            weissHerbPatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.ICY_BASALT,
-                "null",
-                0,
-                0,
-                11325,
-                weissHerbPatchPoint,
-                weissIcyBasaltItems
-        );
+                1
+            ))
+        ));
 
-        List<ItemRequirement> weissPortalNexusItems = getHouseTeleportItemRequirements();
-        Location.Teleport weissPortalNexus = weissLocation.new Teleport(
-                "Portal_Nexus",
-                Location.TeleportCategory.PORTAL_NEXUS,
-                "Teleport to Weiss with Portal Nexus.",
-                0,
-                "null",
-                17,
-                13,
-                11325,
-                weissHerbPatchPoint,
-                weissPortalNexusItems
-        );
-
-        weissLocation.addTeleportOption(weissIcyBasalt);
-        weissLocation.addTeleportOption(weissPortalNexus);
+        weissLocation.addTeleportOption(weissLocation.new Teleport(
+            "Portal_Nexus",
+            Location.TeleportCategory.PORTAL_NEXUS,
+            "Teleport to Weiss with Portal Nexus.",
+            0,
+            "null",
+            17,
+            13,
+            11325,
+            weissHerbPatchPoint,
+            getHouseTeleportItemRequirements()
+        ));
 
         locations.add(weissLocation);
     }

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/HerbRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/HerbRunItemAndLocation.java
@@ -21,18 +21,22 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
     public Location trollStrongholdLocation;
     public Location weissLocation;
 
-    public HerbRunItemAndLocation() {
+    public HerbRunItemAndLocation()
+    {
     }
 
-    public HerbRunItemAndLocation(FarmingHelperConfig config, Client client, FarmingHelperPlugin plugin) {
+    public HerbRunItemAndLocation(FarmingHelperConfig config, Client client, FarmingHelperPlugin plugin)
+    {
         super(config, client, plugin);
     }
 
-    public Map<Integer, Integer> getHerbItems() {
+    public Map<Integer, Integer> getHerbItems()
+    {
         return getAllItemRequirements(locations);
     }
 
-    public Map<Integer, Integer> getAllItemRequirements(List<Location> locations) {
+    public Map<Integer, Integer> getAllItemRequirements(List<Location> locations)
+    {
         Map<Integer, Integer> allRequirements = new HashMap<>();
 
         setupLocations();
@@ -87,7 +91,8 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
         return allRequirements;
     }
 
-    public void setupLocations() {
+    public void setupLocations()
+    {
         super.setupLocations();
 
         setupArdougneLocation();

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/HerbRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/HerbRunItemAndLocation.java
@@ -176,6 +176,19 @@ public class HerbRunItemAndLocation extends ItemAndLocation
         );
 
         ardougneLocation.addTeleportOption(ardougneLocation.new Teleport(
+            "Portal_Nexus",
+            Location.TeleportCategory.PORTAL_NEXUS,
+            "Teleport to Ardougne with Portal Nexus.",
+            0,
+            "null",
+            17,
+            13,
+            10547,
+            ardougneHerbPatchPoint,
+            getHouseTeleportItemRequirements()
+        ));
+
+        ardougneLocation.addTeleportOption(ardougneLocation.new Teleport(
             "Ardougne_teleport",
             Location.TeleportCategory.SPELLBOOK,
             "Teleport to Ardougne with standard spellbook, and run north.",
@@ -296,9 +309,9 @@ public class HerbRunItemAndLocation extends ItemAndLocation
         );
 
         catherbyLocation.addTeleportOption(catherbyLocation.new Teleport(
-            "Portal_nexus",
+            "Portal_Nexus",
             Location.TeleportCategory.PORTAL_NEXUS,
-            "Teleport to Catherby with Portal nexus.",
+            "Teleport to Catherby with Portal Nexus.",
             0,
             "null",
             17,
@@ -379,6 +392,19 @@ public class HerbRunItemAndLocation extends ItemAndLocation
             "Falador",
             true
         );
+
+        faladorLocation.addTeleportOption(faladorLocation.new Teleport(
+            "Portal_Nexus",
+            Location.TeleportCategory.PORTAL_NEXUS,
+            "Teleport to Falador with Portal Nexus.",
+            0,
+            "null",
+            17,
+            13,
+            11828,
+            faladorHerbPatchPoint,
+            getHouseTeleportItemRequirements()
+        ));
 
         faladorLocation.addTeleportOption(faladorLocation.new Teleport(
             "Explorers_ring_2",

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/HerbRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/HerbRunItemAndLocation.java
@@ -35,7 +35,7 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
     public Map<Integer, Integer> getAllItemRequirements(List<Location> locations) {
         Map<Integer, Integer> allRequirements = new HashMap<>();
 
-        setupHerbLocations();
+        setupLocations();
 
         // Add other items and merge them with allRequirements
         for (Location location : locations) {
@@ -87,15 +87,30 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
         return allRequirements;
     }
 
-    public void setupHerbLocations() {
-        // Clear the existing locations list
-        locations.clear();
+    public void setupLocations() {
+        super.setupLocations();
+
+        setupArdougneLocation();
+        setupCatherbyLocation();
+        setupFaladorLocation();
+        setupFarmingGuildLocation();
+        setupHarmonyLocation();
+        setupKourendLocation();
+        setupMorytaniaLocation();
+        setupTrollStrongholdLocation();
+        setupWeissLocation();
+    }
+
+    private void setupArdougneLocation()
+    {
         WorldPoint ardougneHerbPatchPoint = new WorldPoint(2670, 3374, 0);
+
         ardougneLocation = new Location(FarmingHelperConfig::enumOptionEnumArdougneTeleport, config, "Ardougne", true);
 
         List<ItemRequirement> ardougneTeleportItem = Arrays.asList(
                 new ItemRequirement(ItemID.LAW_RUNE, 2),
-                new ItemRequirement(ItemID.WATER_RUNE, 2));
+                new ItemRequirement(ItemID.WATER_RUNE, 2)
+        );
         Location.Teleport ardougneTeleport = ardougneLocation.new Teleport(
                 "Ardougne_teleport",
                 Location.TeleportCategory.SPELLBOOK,
@@ -108,8 +123,10 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 ardougneHerbPatchPoint,
                 ardougneTeleportItem
         );
+
         List<ItemRequirement> ardougneTeleTabItem = Arrays.asList(
-                new ItemRequirement(ItemID.ARDOUGNE_TELEPORT, 1));
+                new ItemRequirement(ItemID.ARDOUGNE_TELEPORT, 1)
+        );
         Location.Teleport ardougneTeleTab = ardougneLocation.new Teleport(
                 "Ardougne_Tele_Tab",
                 Location.TeleportCategory.ITEM,
@@ -124,7 +141,8 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
         );
 
         List<ItemRequirement> ardougneArdyCloak2Item = Arrays.asList(
-                new ItemRequirement(ItemID.ARDOUGNE_CLOAK_2, 1));
+                new ItemRequirement(ItemID.ARDOUGNE_CLOAK_2, 1)
+        );
         Location.Teleport ardougneArdyCloak2 = ardougneLocation.new Teleport(
                 "Ardy_Cloak_2",
                 Location.TeleportCategory.ITEM,
@@ -137,8 +155,10 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 ardougneHerbPatchPoint,
                 ardougneArdyCloak2Item
         );
+
         List<ItemRequirement> ardougneArdyCloak3Item = Arrays.asList(
-                new ItemRequirement(ItemID.ARDOUGNE_CLOAK_3, 1));
+                new ItemRequirement(ItemID.ARDOUGNE_CLOAK_3, 1)
+        );
         Location.Teleport ardougneArdyCloak3 = ardougneLocation.new Teleport(
                 "Ardy_Cloak_3",
                 Location.TeleportCategory.ITEM,
@@ -151,6 +171,7 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 ardougneHerbPatchPoint,
                 ardougneArdyCloak3Item
         );
+
         List<ItemRequirement> ardougneArdyCloak4Item = Arrays.asList(
                 new ItemRequirement(ItemID.ARDOUGNE_CLOAK_4, 1)
         );
@@ -182,16 +203,23 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 ardougneHerbPatchPoint,
                 ardougneSkillsNecklaceItem
         );
+
         ardougneLocation.addTeleportOption(ardougneTeleport);
         ardougneLocation.addTeleportOption(ardougneTeleTab);
         ardougneLocation.addTeleportOption(ardougneArdyCloak2);
         ardougneLocation.addTeleportOption(ardougneArdyCloak3);
         ardougneLocation.addTeleportOption(ardougneArdyCloak4);
         ardougneLocation.addTeleportOption(ardougneSkillsNecklace);
-        locations.add(ardougneLocation);
 
+        locations.add(ardougneLocation);
+    }
+
+    private void setupCatherbyLocation()
+    {
         WorldPoint catherbyHerbPatchPoint = new WorldPoint(2813, 3463, 0);
+
         catherbyLocation = new Location(FarmingHelperConfig::enumOptionEnumCatherbyTeleport, config, "Catherby", true);
+
         List<ItemRequirement> catherbyPortalNexusItems = getHouseTeleportItemRequirements();
         Location.Teleport catherbyPortalNexus = catherbyLocation.new Teleport(
                 "Portal_nexus",
@@ -259,12 +287,19 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
         catherbyLocation.addTeleportOption(catherbyCamelotTeleport);
         catherbyLocation.addTeleportOption(catherbyCamelotTeleTab);
         catherbyLocation.addTeleportOption(catherbyTeleTab);
-        locations.add(catherbyLocation);
 
+        locations.add(catherbyLocation);
+    }
+
+    private void setupFaladorLocation()
+    {
         WorldPoint faladorHerbPatchPoint = new WorldPoint(3058, 3307, 0);
+
         faladorLocation = new Location(FarmingHelperConfig::enumOptionEnumFaladorTeleport, config, "Falador", true);
+
         List<ItemRequirement> faladorExplorersRing2Item = Arrays.asList(
-                new ItemRequirement(ItemID.EXPLORERS_RING_2, 1));
+                new ItemRequirement(ItemID.EXPLORERS_RING_2, 1)
+        );
         Location.Teleport faladorExplorersRing2 = faladorLocation.new Teleport(
                 "Explorers_ring_2",
                 Location.TeleportCategory.ITEM,
@@ -275,10 +310,12 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 0,
                 12083,
                 faladorHerbPatchPoint,
-                faladorExplorersRing2Item);
+                faladorExplorersRing2Item
+        );
 
         List<ItemRequirement> faladorExplorersRing3Item = Arrays.asList(
-                new ItemRequirement(ItemID.EXPLORERS_RING_3, 1));
+                new ItemRequirement(ItemID.EXPLORERS_RING_3, 1)
+        );
         Location.Teleport faladorExplorersRing3 = faladorLocation.new Teleport(
                 "Explorers_ring_3",
                 Location.TeleportCategory.ITEM,
@@ -289,10 +326,12 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 0,
                 12083,
                 faladorHerbPatchPoint,
-                faladorExplorersRing3Item);
+                faladorExplorersRing3Item
+        );
 
         List<ItemRequirement> faladorExplorersRing4Item = Arrays.asList(
-                new ItemRequirement(ItemID.EXPLORERS_RING_4, 1));
+                new ItemRequirement(ItemID.EXPLORERS_RING_4, 1)
+        );
         Location.Teleport faladorExplorersRing4 = faladorLocation.new Teleport(
                 "Explorers_ring_4",
                 Location.TeleportCategory.ITEM,
@@ -303,12 +342,14 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 0,
                 12083,
                 faladorHerbPatchPoint,
-                faladorExplorersRing4Item);
+                faladorExplorersRing4Item
+        );
 
         List<ItemRequirement> faladorTeleportItem = Arrays.asList(
                 new ItemRequirement(ItemID.AIR_RUNE, 3),
                 new ItemRequirement(ItemID.LAW_RUNE, 1),
-                new ItemRequirement(ItemID.WATER_RUNE, 1));
+                new ItemRequirement(ItemID.WATER_RUNE, 1)
+        );
         Location.Teleport faladorTeleport = faladorLocation.new Teleport(
                 "Falador_Teleport",
                 Location.TeleportCategory.SPELLBOOK,
@@ -319,10 +360,12 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 27,
                 11828,
                 faladorHerbPatchPoint,
-                faladorTeleportItem);
+                faladorTeleportItem
+        );
 
         List<ItemRequirement> faladorTeleTabItem = Arrays.asList(
-                new ItemRequirement(ItemID.FALADOR_TELEPORT, 1));
+                new ItemRequirement(ItemID.FALADOR_TELEPORT, 1)
+        );
         Location.Teleport faladorTeleTab = faladorLocation.new Teleport(
                 "Falador_Tele_Tab",
                 Location.TeleportCategory.ITEM,
@@ -333,10 +376,12 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 0,
                 11828,
                 faladorHerbPatchPoint,
-                faladorTeleTabItem);
+                faladorTeleTabItem
+        );
 
         List<ItemRequirement> faladorDraynorManorTeleTabItem = Arrays.asList(
-                new ItemRequirement(ItemID.DRAYNOR_MANOR_TELEPORT, 1));
+                new ItemRequirement(ItemID.DRAYNOR_MANOR_TELEPORT, 1)
+        );
         Location.Teleport faladorDraynorManorTeleTab = faladorLocation.new Teleport(
                 "Draynor_Tele_Tab",
                 Location.TeleportCategory.ITEM,
@@ -347,7 +392,8 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 0,
                 12340,
                 faladorHerbPatchPoint,
-                faladorDraynorManorTeleTabItem);
+                faladorDraynorManorTeleTabItem
+        );
 
         faladorLocation.addTeleportOption(faladorExplorersRing2);
         faladorLocation.addTeleportOption(faladorExplorersRing3);
@@ -355,10 +401,16 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
         faladorLocation.addTeleportOption(faladorTeleport);
         faladorLocation.addTeleportOption(faladorTeleTab);
         faladorLocation.addTeleportOption(faladorDraynorManorTeleTab);
-        locations.add(faladorLocation);
 
+        locations.add(faladorLocation);
+    }
+
+    private void setupFarmingGuildLocation()
+    {
         WorldPoint farmingGuildHerbPatchPoint = new WorldPoint(1238, 3726, 0);
+
         farmingGuildLocation = new Location(FarmingHelperConfig::enumOptionEnumFarmingGuildTeleport, config, "Farming Guild", true);
+
         List<ItemRequirement> farmingGuildJewelleryBoxItems = getHouseTeleportItemRequirements();
         Location.Teleport farmingGuildJewelleryBox = farmingGuildLocation.new Teleport(
                 "Jewellery_box",
@@ -374,7 +426,8 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
         );
 
         List<ItemRequirement> farmingGuildSkillsNecklaceItems = Arrays.asList(
-                new ItemRequirement(ItemID.SKILLS_NECKLACE1, 1));
+                new ItemRequirement(ItemID.SKILLS_NECKLACE1, 1)
+        );
         Location.Teleport farmingGuildSkillsNecklace = farmingGuildLocation.new Teleport(
                 "Skills_Necklace",
                 Location.TeleportCategory.ITEM,
@@ -387,12 +440,19 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 farmingGuildHerbPatchPoint,
                 farmingGuildSkillsNecklaceItems
         );
+
         farmingGuildLocation.addTeleportOption(farmingGuildJewelleryBox);
         farmingGuildLocation.addTeleportOption(farmingGuildSkillsNecklace);
-        locations.add(farmingGuildLocation);
 
+        locations.add(farmingGuildLocation);
+    }
+
+    private void setupHarmonyLocation()
+    {
         WorldPoint harmonyHerbPatchPoint = new WorldPoint(3789, 2837, 0);
+
         harmonyLocation = new Location(FarmingHelperConfig::enumOptionEnumHarmonyTeleport, config, "Harmony Island", false);
+
         List<ItemRequirement> harmonyPortalNexusItems = getHouseTeleportItemRequirements();
         Location.Teleport harmonyPortalNexus = harmonyLocation.new Teleport(
                 "Portal_Nexus",
@@ -404,12 +464,12 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 13,
                 15148,
                 harmonyHerbPatchPoint,
-                harmonyPortalNexusItems);
-        harmonyLocation.addTeleportOption(harmonyPortalNexus);
-        locations.add(harmonyLocation);
+                harmonyPortalNexusItems
+        );
 
         List<ItemRequirement> harmonyTeleTabItems = Arrays.asList(
-                new ItemRequirement(ItemID.HARMONY_ISLAND_TELEPORT, 1));
+                new ItemRequirement(ItemID.HARMONY_ISLAND_TELEPORT, 1)
+        );
         Location.Teleport harmonyTeleTab = harmonyLocation.new Teleport(
                 "Harmony_Tele_Tab",
                 Location.TeleportCategory.ITEM,
@@ -420,13 +480,21 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 0,
                 15148,
                 harmonyHerbPatchPoint,
-                harmonyTeleTabItems);
+                harmonyTeleTabItems
+        );
+
         harmonyLocation.addTeleportOption(harmonyPortalNexus);
         harmonyLocation.addTeleportOption(harmonyTeleTab);
-        locations.add(harmonyLocation);
 
+        locations.add(harmonyLocation);
+    }
+
+    private void setupKourendLocation()
+    {
         WorldPoint kourendHerbPatchPoint = new WorldPoint(1738, 3550, 0);
+
         kourendLocation = new Location(FarmingHelperConfig::enumOptionEnumKourendTeleport, config, "Kourend", true);
+
         List<ItemRequirement> kourendXericsTalismanItems = Arrays.asList(
                 new ItemRequirement(ItemID.XERICS_TALISMAN, 1)
         );
@@ -442,6 +510,7 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 kourendHerbPatchPoint,
                 kourendXericsTalismanItems
         );
+
         List<ItemRequirement> kourendMountedXericsItems = getHouseTeleportItemRequirements();
         Location.Teleport kourendMountedXerics = kourendLocation.new Teleport(
                 "Mounted_Xerics",
@@ -455,12 +524,19 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 kourendHerbPatchPoint,
                 kourendMountedXericsItems
         );
+
         kourendLocation.addTeleportOption(kourendXericsTalisman);
         kourendLocation.addTeleportOption(kourendMountedXerics);
-        locations.add(kourendLocation);
 
+        locations.add(kourendLocation);
+    }
+
+    private void setupMorytaniaLocation()
+    {
         WorldPoint morytaniaHerbPatchPoint = new WorldPoint(3601, 3525, 0);
+
         morytaniaLocation = new Location(FarmingHelperConfig::enumOptionEnumMorytaniaTeleport, config, "Morytania", true);
+
         List<ItemRequirement> morytaniaEctophialItems = Arrays.asList(
                 new ItemRequirement(ItemID.ECTOPHIAL, 1)
         );
@@ -476,11 +552,18 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 morytaniaHerbPatchPoint,
                 morytaniaEctophialItems
         );
-        morytaniaLocation.addTeleportOption(morytaniaEctophial);
-        locations.add(morytaniaLocation);
 
+        morytaniaLocation.addTeleportOption(morytaniaEctophial);
+
+        locations.add(morytaniaLocation);
+    }
+
+    private void setupTrollStrongholdLocation()
+    {
         WorldPoint trollStrongholhHerbPatchPoint = new WorldPoint(2824, 3696, 0);
+
         trollStrongholdLocation = new Location(FarmingHelperConfig::enumOptionEnumTrollStrongholdTeleport, config, "Troll Stronghold", false);
+
         List<ItemRequirement> tsStonyBasaltItems = Arrays.asList(
                 new ItemRequirement(ItemID.STONY_BASALT, 1)
         );
@@ -496,6 +579,7 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 trollStrongholhHerbPatchPoint,
                 tsStonyBasaltItems
         );
+
         List<ItemRequirement> tsPortalNexusItems = getHouseTeleportItemRequirements();
         Location.Teleport tsPortalNexus = trollStrongholdLocation.new Teleport(
                 "Portal_Nexus",
@@ -509,12 +593,19 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 trollStrongholhHerbPatchPoint,
                 tsPortalNexusItems
         );
+
         trollStrongholdLocation.addTeleportOption(tsStonyBasalt);
         trollStrongholdLocation.addTeleportOption(tsPortalNexus);
-        locations.add(trollStrongholdLocation);
 
+        locations.add(trollStrongholdLocation);
+    }
+
+    private void setupWeissLocation()
+    {
         WorldPoint weissHerbPatchPoint = new WorldPoint(2847, 3931, 0);
+
         weissLocation = new Location(FarmingHelperConfig::enumOptionEnumWeissTeleport, config, "Weiss", false);
+
         List<ItemRequirement> weissIcyBasaltItems = Arrays.asList(
                 new ItemRequirement(ItemID.ICY_BASALT, 1)
         );
@@ -530,6 +621,7 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 weissHerbPatchPoint,
                 weissIcyBasaltItems
         );
+
         List<ItemRequirement> weissPortalNexusItems = getHouseTeleportItemRequirements();
         Location.Teleport weissPortalNexus = weissLocation.new Teleport(
                 "Portal_Nexus",
@@ -543,9 +635,10 @@ public class HerbRunItemAndLocation extends ItemAndLocation {
                 weissHerbPatchPoint,
                 weissPortalNexusItems
         );
+
         weissLocation.addTeleportOption(weissIcyBasalt);
         weissLocation.addTeleportOption(weissPortalNexus);
-        locations.add(weissLocation);
 
+        locations.add(weissLocation);
     }
 }

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/HerbRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/HerbRunItemAndLocation.java
@@ -309,7 +309,7 @@ public class HerbRunItemAndLocation extends ItemAndLocation
         );
 
         catherbyLocation.addTeleportOption(catherbyLocation.new Teleport(
-            "Portal_Nexus",
+            "Portal_Nexus_Catherby",
             Location.TeleportCategory.PORTAL_NEXUS,
             "Teleport to Catherby with Portal Nexus.",
             0,
@@ -317,6 +317,19 @@ public class HerbRunItemAndLocation extends ItemAndLocation
             17,
             13,
             11061,
+            catherbyHerbPatchPoint,
+            getHouseTeleportItemRequirements()
+        ));
+
+        catherbyLocation.addTeleportOption(catherbyLocation.new Teleport(
+            "Portal_Nexus_Camelot",
+            Location.TeleportCategory.PORTAL_NEXUS,
+            "Teleport to Camelot with Portal Nexus.",
+            0,
+            "null",
+            17,
+            13,
+            11062,
             catherbyHerbPatchPoint,
             getHouseTeleportItemRequirements()
         ));

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/ItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/ItemAndLocation.java
@@ -1,0 +1,84 @@
+package com.farminghelper.speaax.ItemsAndLocations;
+
+import com.farminghelper.speaax.FarmingHelperConfig;
+import com.farminghelper.speaax.FarmingHelperPlugin;
+import com.farminghelper.speaax.ItemRequirement;
+import com.farminghelper.speaax.Location;
+import net.runelite.api.Client;
+import net.runelite.api.ItemID;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ItemAndLocation {
+    protected FarmingHelperConfig config;
+    protected Client client;
+    protected FarmingHelperPlugin plugin;
+
+    public List<Location> locations = new ArrayList<>();
+
+    public ItemAndLocation() {
+    }
+
+    public ItemAndLocation(FarmingHelperConfig config, Client client, FarmingHelperPlugin plugin) {
+        this.config = config;
+        this.client = client;
+        this.plugin = plugin;
+    }
+
+    public List<ItemRequirement> getHouseTeleportItemRequirements() {
+        FarmingHelperConfig.OptionEnumHouseTele selectedOption = config.enumConfigHouseTele();
+        List<ItemRequirement> itemRequirements = new ArrayList<>();
+
+        switch (selectedOption) {
+            case Law_air_earth_runes:
+                itemRequirements.add(new ItemRequirement(ItemID.AIR_RUNE, 1));
+                itemRequirements.add(new ItemRequirement(ItemID.EARTH_RUNE, 1));
+                itemRequirements.add(new ItemRequirement(ItemID.LAW_RUNE, 1));
+                break;
+
+//            case Law_dust_runes:
+//                itemRequirements.add(new ItemRequirement(ItemID.DUST_RUNE, 1));
+//                itemRequirements.add(new ItemRequirement(ItemID.LAW_RUNE, 1));
+//                break;
+
+            case Teleport_To_House:
+                itemRequirements.add(new ItemRequirement(ItemID.TELEPORT_TO_HOUSE, 1));
+                break;
+
+            case Construction_cape:
+                itemRequirements.add(new ItemRequirement(ItemID.CONSTRUCT_CAPE, 1));
+                break;
+
+            case Construction_cape_t:
+                itemRequirements.add(new ItemRequirement(ItemID.CONSTRUCT_CAPET, 1));
+                break;
+
+            case Max_cape:
+                itemRequirements.add(new ItemRequirement(ItemID.MAX_CAPE, 1));
+                break;
+
+            default:
+                throw new IllegalStateException("Unexpected value: " + selectedOption);
+        }
+
+        return itemRequirements;
+    }
+
+    public Integer selectedCompostID() {
+        FarmingHelperConfig.OptionEnumCompost selectedCompost = config.enumConfigCompost();
+
+        switch (selectedCompost) {
+            case Compost:
+                return ItemID.COMPOST;
+            case Supercompost:
+                return ItemID.SUPERCOMPOST;
+            case Ultracompost:
+                return ItemID.ULTRACOMPOST;
+            case Bottomless:
+                return ItemID.BOTTOMLESS_COMPOST_BUCKET_22997;
+        }
+
+        return -1;
+    }
+}

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/ItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/ItemAndLocation.java
@@ -10,9 +10,12 @@ import net.runelite.api.ItemID;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ItemAndLocation {
+public class ItemAndLocation
+{
     protected FarmingHelperConfig config;
+
     protected Client client;
+
     protected FarmingHelperPlugin plugin;
 
     public List<Location> locations = new ArrayList<>();
@@ -36,30 +39,66 @@ public class ItemAndLocation {
 
         switch (selectedOption) {
             case Law_air_earth_runes:
-                itemRequirements.add(new ItemRequirement(ItemID.AIR_RUNE, 1));
-                itemRequirements.add(new ItemRequirement(ItemID.EARTH_RUNE, 1));
-                itemRequirements.add(new ItemRequirement(ItemID.LAW_RUNE, 1));
+                itemRequirements.add(new ItemRequirement(
+                    ItemID.AIR_RUNE,
+                    1
+                ));
+
+                itemRequirements.add(new ItemRequirement(
+                    ItemID.EARTH_RUNE,
+                    1
+                ));
+
+                itemRequirements.add(new ItemRequirement(
+                    ItemID.LAW_RUNE,
+                    1
+                ));
+
                 break;
 
-//            case Law_dust_runes:
-//                itemRequirements.add(new ItemRequirement(ItemID.DUST_RUNE, 1));
-//                itemRequirements.add(new ItemRequirement(ItemID.LAW_RUNE, 1));
-//                break;
+            // case Law_dust_runes:
+            //     itemRequirements.add(new ItemRequirement(
+            //         ItemID.DUST_RUNE,
+            //         1
+            //     ));
+            //
+            //     itemRequirements.add(new ItemRequirement(
+            //         ItemID.LAW_RUNE,
+            //         1
+            //     ));
+            //
+            //     break;
 
             case Teleport_To_House:
-                itemRequirements.add(new ItemRequirement(ItemID.TELEPORT_TO_HOUSE, 1));
+                itemRequirements.add(new ItemRequirement(
+                    ItemID.TELEPORT_TO_HOUSE,
+                    1
+                ));
+
                 break;
 
             case Construction_cape:
-                itemRequirements.add(new ItemRequirement(ItemID.CONSTRUCT_CAPE, 1));
+                itemRequirements.add(new ItemRequirement(
+                    ItemID.CONSTRUCT_CAPE,
+                    1
+                ));
+
                 break;
 
             case Construction_cape_t:
-                itemRequirements.add(new ItemRequirement(ItemID.CONSTRUCT_CAPET, 1));
+                itemRequirements.add(new ItemRequirement(
+                    ItemID.CONSTRUCT_CAPET,
+                    1
+                ));
+
                 break;
 
             case Max_cape:
-                itemRequirements.add(new ItemRequirement(ItemID.MAX_CAPE, 1));
+                itemRequirements.add(new ItemRequirement(
+                    ItemID.MAX_CAPE,
+                    1
+                ));
+
                 break;
 
             default:
@@ -87,12 +126,11 @@ public class ItemAndLocation {
                 return ItemID.BOTTOMLESS_COMPOST_BUCKET_22997;
         }
 
-        return -1;
+        return - 1;
     }
 
     public void setupLocations()
     {
-        // Clear the existing locations list
         locations.clear();
     }
 }

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/ItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/ItemAndLocation.java
@@ -17,17 +17,21 @@ public class ItemAndLocation {
 
     public List<Location> locations = new ArrayList<>();
 
-    public ItemAndLocation() {
+    public ItemAndLocation()
+    {
     }
 
-    public ItemAndLocation(FarmingHelperConfig config, Client client, FarmingHelperPlugin plugin) {
+    public ItemAndLocation(FarmingHelperConfig config, Client client, FarmingHelperPlugin plugin)
+    {
         this.config = config;
         this.client = client;
         this.plugin = plugin;
     }
 
-    public List<ItemRequirement> getHouseTeleportItemRequirements() {
+    public List<ItemRequirement> getHouseTeleportItemRequirements()
+    {
         FarmingHelperConfig.OptionEnumHouseTele selectedOption = config.enumConfigHouseTele();
+
         List<ItemRequirement> itemRequirements = new ArrayList<>();
 
         switch (selectedOption) {
@@ -65,20 +69,30 @@ public class ItemAndLocation {
         return itemRequirements;
     }
 
-    public Integer selectedCompostID() {
+    public Integer selectedCompostID()
+    {
         FarmingHelperConfig.OptionEnumCompost selectedCompost = config.enumConfigCompost();
 
         switch (selectedCompost) {
             case Compost:
                 return ItemID.COMPOST;
+
             case Supercompost:
                 return ItemID.SUPERCOMPOST;
+
             case Ultracompost:
                 return ItemID.ULTRACOMPOST;
+
             case Bottomless:
                 return ItemID.BOTTOMLESS_COMPOST_BUCKET_22997;
         }
 
         return -1;
+    }
+
+    public void setupLocations()
+    {
+        // Clear the existing locations list
+        locations.clear();
     }
 }

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/TreeRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/TreeRunItemAndLocation.java
@@ -10,12 +10,7 @@ import net.runelite.api.coords.WorldPoint;
 
 import java.util.*;
 
-public class TreeRunItemAndLocation {
-    private FarmingHelperConfig config;
-
-    private Client client;
-    private FarmingHelperPlugin plugin;
-
+public class TreeRunItemAndLocation extends ItemAndLocation {
     public Location faladorTreeLocation;
     public Location farmingGuildTreeLocation;
     public Location gnomeStrongholdTreeLocation;
@@ -23,60 +18,22 @@ public class TreeRunItemAndLocation {
     public Location taverleyTreeLocation;
     public Location varrockTreeLocation;
 
-
-    public List<Location> locations = new ArrayList<>();
     public TreeRunItemAndLocation() {
     }
 
     public TreeRunItemAndLocation(FarmingHelperConfig config, Client client, FarmingHelperPlugin plugin) {
-        this.config = config;
-        this.client = client;
-        this.plugin = plugin;
+        super(config, client, plugin);
     }
 
     public Map<Integer, Integer> getTreeItems() {
         return getAllItemRequirements(locations);
     }
 
-    public List<ItemRequirement> getHouseTeleportItemRequirements() {
-        FarmingHelperConfig.OptionEnumHouseTele selectedOption = config.enumConfigHouseTele();
-        List<ItemRequirement> itemRequirements = new ArrayList<>();
-
-        switch (selectedOption) {
-            case Law_air_earth_runes:
-                itemRequirements.add(new ItemRequirement(ItemID.AIR_RUNE, 1));
-                itemRequirements.add(new ItemRequirement(ItemID.EARTH_RUNE, 1));
-                itemRequirements.add(new ItemRequirement(ItemID.LAW_RUNE, 1));
-                break;
-                /*
-            case Law_dust_runes:
-                itemRequirements.add(new ItemRequirement(ItemID.DUST_RUNE, 1));
-                itemRequirements.add(new ItemRequirement(ItemID.LAW_RUNE, 1));
-                break;
-
-                 */
-            case Teleport_To_House:
-                itemRequirements.add(new ItemRequirement(ItemID.TELEPORT_TO_HOUSE, 1));
-                break;
-            case Construction_cape:
-                itemRequirements.add(new ItemRequirement(ItemID.CONSTRUCT_CAPE, 1));
-                break;
-            case Construction_cape_t:
-                itemRequirements.add(new ItemRequirement(ItemID.CONSTRUCT_CAPET, 1));
-                break;
-            case Max_cape:
-                itemRequirements.add(new ItemRequirement(ItemID.MAX_CAPE, 1));
-                break;
-            default:
-                throw new IllegalStateException("Unexpected value: " + selectedOption);
-        }
-
-        return itemRequirements;
-    }
-
     public Map<Integer, Integer> getAllItemRequirements(List<Location> locations) {
         Map<Integer, Integer> allRequirements = new HashMap<>();
+
         setupTreeLocations();
+
         // Add other items and merge them with allRequirements
         for (Location location : locations) {
             if (plugin.getTreeLocationEnabled(location.getName())) {
@@ -86,6 +43,7 @@ public class TreeRunItemAndLocation {
                 allRequirements.merge(ItemID.COINS_995, 200, Integer::sum);
                 Location.Teleport teleport = location.getSelectedTeleport();
                 Map<Integer, Integer> locationRequirements = teleport.getItemRequirements();
+
                 for (Map.Entry<Integer, Integer> entry : locationRequirements.entrySet()) {
                     int itemId = entry.getKey();
                     int quantity = entry.getValue();
@@ -98,13 +56,19 @@ public class TreeRunItemAndLocation {
                 }
             }
         }
+
         //allRequirements.merge(ItemID.SEED_DIBBER, 1, Integer::sum);
         allRequirements.merge(ItemID.SPADE, 1, Integer::sum);
         allRequirements.merge(ItemID.BOTTOMLESS_COMPOST_BUCKET_22997, 1, Integer::sum);
         allRequirements.merge(ItemID.MAGIC_SECATEURS, 1, Integer::sum);
-        if(config.generalRake()){allRequirements.merge(ItemID.RAKE, 1, Integer::sum);}
+
+        if (config.generalRake()) {
+            allRequirements.merge(ItemID.RAKE, 1, Integer::sum);
+        }
+
         return allRequirements;
     }
+
     public void setupTreeLocations() {
         // Clear the existing locations list
         locations.clear();

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/TreeRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/TreeRunItemAndLocation.java
@@ -18,21 +18,25 @@ public class TreeRunItemAndLocation extends ItemAndLocation {
     public Location taverleyTreeLocation;
     public Location varrockTreeLocation;
 
-    public TreeRunItemAndLocation() {
+    public TreeRunItemAndLocation()
+    {
     }
 
-    public TreeRunItemAndLocation(FarmingHelperConfig config, Client client, FarmingHelperPlugin plugin) {
+    public TreeRunItemAndLocation(FarmingHelperConfig config, Client client, FarmingHelperPlugin plugin)
+    {
         super(config, client, plugin);
     }
 
-    public Map<Integer, Integer> getTreeItems() {
+    public Map<Integer, Integer> getTreeItems()
+    {
         return getAllItemRequirements(locations);
     }
 
-    public Map<Integer, Integer> getAllItemRequirements(List<Location> locations) {
+    public Map<Integer, Integer> getAllItemRequirements(List<Location> locations)
+    {
         Map<Integer, Integer> allRequirements = new HashMap<>();
 
-        setupTreeLocations();
+        setupLocations();
 
         // Add other items and merge them with allRequirements
         for (Location location : locations) {
@@ -69,16 +73,29 @@ public class TreeRunItemAndLocation extends ItemAndLocation {
         return allRequirements;
     }
 
-    public void setupTreeLocations() {
-        // Clear the existing locations list
-        locations.clear();
+    public void setupLocations()
+    {
+        super.setupLocations();
+
+        setupFaladorLocation();
+        setupFarmingGuildLocation();
+        setupGnomeStrongholdLocation();
+        setupLumbridgeLocation();
+        setupTaverleyLocation();
+        setupVarrockLocation();
+    }
+
+    private void setupFaladorLocation()
+    {
+        WorldPoint faladorTreePatchPoint = new WorldPoint(3000, 3373, 0);
 
         faladorTreeLocation = new Location(FarmingHelperConfig::enumTreeFaladorTeleport, config, "Falador", false);
+
         List<ItemRequirement> faladorTreeTeleportItems = Arrays.asList(
                 new ItemRequirement(ItemID.AIR_RUNE, 3),
                 new ItemRequirement(ItemID.LAW_RUNE, 1),
-                new ItemRequirement(ItemID.WATER_RUNE, 1));
-        WorldPoint faladorTreePatchPoint = new WorldPoint(3000, 3373, 0);
+                new ItemRequirement(ItemID.WATER_RUNE, 1)
+        );
         Location.Teleport faladorTreeTeleport = faladorTreeLocation.new Teleport(
                 "Falador_teleport",
                 Location.TeleportCategory.SPELLBOOK,
@@ -89,13 +106,21 @@ public class TreeRunItemAndLocation extends ItemAndLocation {
                 27,
                 11828,
                 faladorTreePatchPoint,
-                faladorTreeTeleportItems);
+                faladorTreeTeleportItems
+        );
+
         faladorTreeLocation.addTeleportOption(faladorTreeTeleport);
+
         locations.add(faladorTreeLocation);
+    }
+
+    private void setupFarmingGuildLocation()
+    {
+        WorldPoint farmingGuildTreePatchPoint = new WorldPoint(1232, 3736, 0);
 
         farmingGuildTreeLocation = new Location(FarmingHelperConfig::enumTreeFarmingGuildTeleport, config, "Farming Guild", false);
+
         List<ItemRequirement> farmingGuildTreeTeleportItems = getHouseTeleportItemRequirements();
-        WorldPoint farmingGuildTreePatchPoint = new WorldPoint(1232, 3736, 0);
         Location.Teleport farmingGuildTreeTeleport = farmingGuildTreeLocation.new Teleport(
                 "Jewellery_box",
                 Location.TeleportCategory.JEWELLERY_BOX,
@@ -106,14 +131,23 @@ public class TreeRunItemAndLocation extends ItemAndLocation {
                 0,
                 4922,
                 farmingGuildTreePatchPoint,
-                farmingGuildTreeTeleportItems);
+                farmingGuildTreeTeleportItems
+        );
+
         farmingGuildTreeLocation.addTeleportOption(farmingGuildTreeTeleport);
+
         locations.add(farmingGuildTreeLocation);
+    }
+
+    private void setupGnomeStrongholdLocation()
+    {
+        WorldPoint gnomeStrongholdTreePatchPoint = new WorldPoint(2436, 3415, 0);
 
         gnomeStrongholdTreeLocation = new Location(FarmingHelperConfig::enumTreeGnomeStrongoldTeleport, config, "Gnome Stronghold", false);
+
         List<ItemRequirement> gnomeStrongholdTreeTeleportItems = Arrays.asList(
-                new ItemRequirement(ItemID.ROYAL_SEED_POD, 1));
-        WorldPoint gnomeStrongholdTreePatchPoint = new WorldPoint(2436, 3415, 0);
+                new ItemRequirement(ItemID.ROYAL_SEED_POD, 1)
+        );
         Location.Teleport gnomeStrongholdTreeTeleport = gnomeStrongholdTreeLocation.new Teleport(
                 "Royal_seed_pod",
                 Location.TeleportCategory.ITEM,
@@ -124,16 +158,25 @@ public class TreeRunItemAndLocation extends ItemAndLocation {
                 0,
                 9782,
                 gnomeStrongholdTreePatchPoint,
-                gnomeStrongholdTreeTeleportItems);
+                gnomeStrongholdTreeTeleportItems
+        );
+
         gnomeStrongholdTreeLocation.addTeleportOption(gnomeStrongholdTreeTeleport);
+
         locations.add(gnomeStrongholdTreeLocation);
+    }
+
+    private void setupLumbridgeLocation()
+    {
+        WorldPoint lumbridgeTreePatchPoint = new WorldPoint(3193, 3231, 0);
 
         lumbridgeTreeLocation = new Location(FarmingHelperConfig::enumTreeLumbridgeTeleport, config, "Lumbridge", false);
+
         List<ItemRequirement> lumbridgeTreeTeleportItems = Arrays.asList(
                 new ItemRequirement(ItemID.AIR_RUNE, 3),
                 new ItemRequirement(ItemID.LAW_RUNE, 1),
-                new ItemRequirement(ItemID.EARTH_RUNE, 1));
-        WorldPoint lumbridgeTreePatchPoint = new WorldPoint(3193, 3231, 0);
+                new ItemRequirement(ItemID.EARTH_RUNE, 1)
+        );
         Location.Teleport lumbridgeTreeTeleport = lumbridgeTreeLocation.new Teleport(
                 "Lumbridge_teleport",
                 Location.TeleportCategory.SPELLBOOK,
@@ -144,16 +187,25 @@ public class TreeRunItemAndLocation extends ItemAndLocation {
                 24,
                 12850,
                 lumbridgeTreePatchPoint,
-                lumbridgeTreeTeleportItems);
+                lumbridgeTreeTeleportItems
+        );
+
         lumbridgeTreeLocation.addTeleportOption(lumbridgeTreeTeleport);
+
         locations.add(lumbridgeTreeLocation);
+    }
+
+    private void setupTaverleyLocation()
+    {
+        WorldPoint taverlyPatchPoint = new WorldPoint(2936, 3438, 0);
 
         taverleyTreeLocation = new Location(FarmingHelperConfig::enumTreeTaverleyTeleport, config, "Taverley", false);
+
         List<ItemRequirement> taverleyTreeTeleportItems = Arrays.asList(
                 new ItemRequirement(ItemID.AIR_RUNE, 3),
                 new ItemRequirement(ItemID.LAW_RUNE, 1),
-                new ItemRequirement(ItemID.WATER_RUNE, 1));
-        WorldPoint taverlyPatchPoint = new WorldPoint(2936, 3438, 0);
+                new ItemRequirement(ItemID.WATER_RUNE, 1)
+        );
         Location.Teleport taverleyTreeTeleport = taverleyTreeLocation.new Teleport(
                 "Falador_teleport",
                 Location.TeleportCategory.SPELLBOOK,
@@ -164,16 +216,25 @@ public class TreeRunItemAndLocation extends ItemAndLocation {
                 27,
                 11828,
                 taverlyPatchPoint,
-                taverleyTreeTeleportItems);
+                taverleyTreeTeleportItems
+        );
+
         taverleyTreeLocation.addTeleportOption(taverleyTreeTeleport);
+
         locations.add(taverleyTreeLocation);
+    }
+
+    private void setupVarrockLocation()
+    {
+        WorldPoint varrockTreePatchPoint = new WorldPoint(3229, 3459, 0);
 
         varrockTreeLocation = new Location(FarmingHelperConfig::enumTreeVarrockTeleport, config, "Varrock", false);
+
         List<ItemRequirement> varrockTreeTeleportItems = Arrays.asList(
                 new ItemRequirement(ItemID.AIR_RUNE, 3),
                 new ItemRequirement(ItemID.LAW_RUNE, 1),
-                new ItemRequirement(ItemID.FIRE_RUNE, 1));
-        WorldPoint varrockTreePatchPoint = new WorldPoint(3229, 3459, 0);
+                new ItemRequirement(ItemID.FIRE_RUNE, 1)
+        );
         Location.Teleport varrockTreeTeleport = varrockTreeLocation.new Teleport(
                 "Varrock_teleport",
                 Location.TeleportCategory.SPELLBOOK,
@@ -184,8 +245,11 @@ public class TreeRunItemAndLocation extends ItemAndLocation {
                 21,
                 12853,
                 varrockTreePatchPoint,
-                varrockTreeTeleportItems);
+                varrockTreeTeleportItems
+        );
+
         varrockTreeLocation.addTeleportOption(varrockTreeTeleport);
+
         locations.add(varrockTreeLocation);
     }
 }

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/TreeRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/TreeRunItemAndLocation.java
@@ -10,7 +10,8 @@ import net.runelite.api.coords.WorldPoint;
 
 import java.util.*;
 
-public class TreeRunItemAndLocation extends ItemAndLocation {
+public class TreeRunItemAndLocation extends ItemAndLocation
+{
     public Location faladorTreeLocation;
     public Location farmingGuildTreeLocation;
     public Location gnomeStrongholdTreeLocation;
@@ -24,7 +25,11 @@ public class TreeRunItemAndLocation extends ItemAndLocation {
 
     public TreeRunItemAndLocation(FarmingHelperConfig config, Client client, FarmingHelperPlugin plugin)
     {
-        super(config, client, plugin);
+        super(
+            config,
+            client,
+            plugin
+        );
     }
 
     public Map<Integer, Integer> getTreeItems()
@@ -43,9 +48,20 @@ public class TreeRunItemAndLocation extends ItemAndLocation {
             if (plugin.getTreeLocationEnabled(location.getName())) {
                 //ItemID.GUAM_SEED is default for herb seeds, code later will allow for any seed to be used, just needed a placeholder ID
                 //allRequirements.merge(ItemID.GUAM_SEED, 1, Integer::sum);
-                allRequirements.merge(ItemID.OAK_SAPLING, 1, Integer::sum);
-                allRequirements.merge(ItemID.COINS_995, 200, Integer::sum);
+                allRequirements.merge(
+                    ItemID.OAK_SAPLING,
+                    1,
+                    Integer::sum
+                );
+
+                allRequirements.merge(
+                    ItemID.COINS_995,
+                    200,
+                    Integer::sum
+                );
+
                 Location.Teleport teleport = location.getSelectedTeleport();
+
                 Map<Integer, Integer> locationRequirements = teleport.getItemRequirements();
 
                 for (Map.Entry<Integer, Integer> entry : locationRequirements.entrySet()) {
@@ -53,21 +69,50 @@ public class TreeRunItemAndLocation extends ItemAndLocation {
                     int quantity = entry.getValue();
 
                     if (itemId == ItemID.CONSTRUCT_CAPE || itemId == ItemID.CONSTRUCT_CAPET || itemId == ItemID.MAX_CAPE) {
-                        allRequirements.merge(itemId, quantity, (oldValue, newValue) -> Math.min(1, oldValue + newValue));
+                        allRequirements.merge(
+                            itemId,
+                            quantity,
+                            (oldValue, newValue) -> Math.min(
+                                1,
+                                oldValue + newValue
+                            )
+                        );
                     } else {
-                        allRequirements.merge(itemId, quantity, Integer::sum);
+                        allRequirements.merge(
+                            itemId,
+                            quantity,
+                            Integer::sum
+                        );
                     }
                 }
             }
         }
 
         //allRequirements.merge(ItemID.SEED_DIBBER, 1, Integer::sum);
-        allRequirements.merge(ItemID.SPADE, 1, Integer::sum);
-        allRequirements.merge(ItemID.BOTTOMLESS_COMPOST_BUCKET_22997, 1, Integer::sum);
-        allRequirements.merge(ItemID.MAGIC_SECATEURS, 1, Integer::sum);
+        allRequirements.merge(
+            ItemID.SPADE,
+            1,
+            Integer::sum
+        );
+
+        allRequirements.merge(
+            ItemID.BOTTOMLESS_COMPOST_BUCKET_22997,
+            1,
+            Integer::sum
+        );
+
+        allRequirements.merge(
+            ItemID.MAGIC_SECATEURS,
+            1,
+            Integer::sum
+        );
 
         if (config.generalRake()) {
-            allRequirements.merge(ItemID.RAKE, 1, Integer::sum);
+            allRequirements.merge(
+                ItemID.RAKE,
+                1,
+                Integer::sum
+            );
         }
 
         return allRequirements;
@@ -87,168 +132,241 @@ public class TreeRunItemAndLocation extends ItemAndLocation {
 
     private void setupFaladorLocation()
     {
-        WorldPoint faladorTreePatchPoint = new WorldPoint(3000, 3373, 0);
-
-        faladorTreeLocation = new Location(FarmingHelperConfig::enumTreeFaladorTeleport, config, "Falador", false);
-
-        List<ItemRequirement> faladorTreeTeleportItems = Arrays.asList(
-                new ItemRequirement(ItemID.AIR_RUNE, 3),
-                new ItemRequirement(ItemID.LAW_RUNE, 1),
-                new ItemRequirement(ItemID.WATER_RUNE, 1)
-        );
-        Location.Teleport faladorTreeTeleport = faladorTreeLocation.new Teleport(
-                "Falador_teleport",
-                Location.TeleportCategory.SPELLBOOK,
-                "Teleport to Falador with Spellbook and run to Falador park.",
-                0,
-                "null",
-                218,
-                27,
-                11828,
-                faladorTreePatchPoint,
-                faladorTreeTeleportItems
+        WorldPoint faladorTreePatchPoint = new WorldPoint(
+            3000,
+            3373,
+            0
         );
 
-        faladorTreeLocation.addTeleportOption(faladorTreeTeleport);
+        faladorTreeLocation = new Location(
+            FarmingHelperConfig::enumTreeFaladorTeleport,
+            config,
+            "Falador",
+            false
+        );
+
+        faladorTreeLocation.addTeleportOption(faladorTreeLocation.new Teleport(
+            "Falador_teleport",
+            Location.TeleportCategory.SPELLBOOK,
+            "Teleport to Falador with Spellbook and run to Falador park.",
+            0,
+            "null",
+            218,
+            27,
+            11828,
+            faladorTreePatchPoint,
+            Arrays.asList(
+                new ItemRequirement(
+                    ItemID.AIR_RUNE,
+                    3
+                ),
+                new ItemRequirement(
+                    ItemID.LAW_RUNE,
+                    1
+                ),
+                new ItemRequirement(
+                    ItemID.WATER_RUNE,
+                    1
+                )
+            )
+        ));
 
         locations.add(faladorTreeLocation);
     }
 
     private void setupFarmingGuildLocation()
     {
-        WorldPoint farmingGuildTreePatchPoint = new WorldPoint(1232, 3736, 0);
-
-        farmingGuildTreeLocation = new Location(FarmingHelperConfig::enumTreeFarmingGuildTeleport, config, "Farming Guild", false);
-
-        List<ItemRequirement> farmingGuildTreeTeleportItems = getHouseTeleportItemRequirements();
-        Location.Teleport farmingGuildTreeTeleport = farmingGuildTreeLocation.new Teleport(
-                "Jewellery_box",
-                Location.TeleportCategory.JEWELLERY_BOX,
-                "Teleport to Farming Guild with Jewellery box.",
-                0,
-                "null",
-                0,
-                0,
-                4922,
-                farmingGuildTreePatchPoint,
-                farmingGuildTreeTeleportItems
+        WorldPoint farmingGuildTreePatchPoint = new WorldPoint(
+            1232,
+            3736,
+            0
         );
 
-        farmingGuildTreeLocation.addTeleportOption(farmingGuildTreeTeleport);
+        farmingGuildTreeLocation = new Location(
+            FarmingHelperConfig::enumTreeFarmingGuildTeleport,
+            config,
+            "Farming Guild",
+            false
+        );
+
+        farmingGuildTreeLocation.addTeleportOption(farmingGuildTreeLocation.new Teleport(
+            "Jewellery_box",
+            Location.TeleportCategory.JEWELLERY_BOX,
+            "Teleport to Farming Guild with Jewellery box.",
+            0,
+            "null",
+            0,
+            0,
+            4922,
+            farmingGuildTreePatchPoint,
+            getHouseTeleportItemRequirements()
+        ));
 
         locations.add(farmingGuildTreeLocation);
     }
 
     private void setupGnomeStrongholdLocation()
     {
-        WorldPoint gnomeStrongholdTreePatchPoint = new WorldPoint(2436, 3415, 0);
-
-        gnomeStrongholdTreeLocation = new Location(FarmingHelperConfig::enumTreeGnomeStrongoldTeleport, config, "Gnome Stronghold", false);
-
-        List<ItemRequirement> gnomeStrongholdTreeTeleportItems = Arrays.asList(
-                new ItemRequirement(ItemID.ROYAL_SEED_POD, 1)
+        WorldPoint gnomeStrongholdTreePatchPoint = new WorldPoint(
+            2436,
+            3415,
+            0
         );
-        Location.Teleport gnomeStrongholdTreeTeleport = gnomeStrongholdTreeLocation.new Teleport(
-                "Royal_seed_pod",
-                Location.TeleportCategory.ITEM,
-                "Teleport to Gnome Stronghold with Royal seed pod.",
+
+        gnomeStrongholdTreeLocation = new Location(
+            FarmingHelperConfig::enumTreeGnomeStrongoldTeleport,
+            config,
+            "Gnome Stronghold",
+            false
+        );
+
+        gnomeStrongholdTreeLocation.addTeleportOption(gnomeStrongholdTreeLocation.new Teleport(
+            "Royal_seed_pod",
+            Location.TeleportCategory.ITEM,
+            "Teleport to Gnome Stronghold with Royal seed pod.",
+            ItemID.ROYAL_SEED_POD,
+            "null",
+            0,
+            0,
+            9782,
+            gnomeStrongholdTreePatchPoint,
+            Collections.singletonList(new ItemRequirement(
                 ItemID.ROYAL_SEED_POD,
-                "null",
-                0,
-                0,
-                9782,
-                gnomeStrongholdTreePatchPoint,
-                gnomeStrongholdTreeTeleportItems
-        );
-
-        gnomeStrongholdTreeLocation.addTeleportOption(gnomeStrongholdTreeTeleport);
+                1
+            ))
+        ));
 
         locations.add(gnomeStrongholdTreeLocation);
     }
 
     private void setupLumbridgeLocation()
     {
-        WorldPoint lumbridgeTreePatchPoint = new WorldPoint(3193, 3231, 0);
-
-        lumbridgeTreeLocation = new Location(FarmingHelperConfig::enumTreeLumbridgeTeleport, config, "Lumbridge", false);
-
-        List<ItemRequirement> lumbridgeTreeTeleportItems = Arrays.asList(
-                new ItemRequirement(ItemID.AIR_RUNE, 3),
-                new ItemRequirement(ItemID.LAW_RUNE, 1),
-                new ItemRequirement(ItemID.EARTH_RUNE, 1)
-        );
-        Location.Teleport lumbridgeTreeTeleport = lumbridgeTreeLocation.new Teleport(
-                "Lumbridge_teleport",
-                Location.TeleportCategory.SPELLBOOK,
-                "Teleport to Lumbridge with spellbook.",
-                0,
-                "null",
-                218,
-                24,
-                12850,
-                lumbridgeTreePatchPoint,
-                lumbridgeTreeTeleportItems
+        WorldPoint lumbridgeTreePatchPoint = new WorldPoint(
+            3193,
+            3231,
+            0
         );
 
-        lumbridgeTreeLocation.addTeleportOption(lumbridgeTreeTeleport);
+        lumbridgeTreeLocation = new Location(
+            FarmingHelperConfig::enumTreeLumbridgeTeleport,
+            config,
+            "Lumbridge",
+            false
+        );
+
+        lumbridgeTreeLocation.addTeleportOption(lumbridgeTreeLocation.new Teleport(
+            "Lumbridge_teleport",
+            Location.TeleportCategory.SPELLBOOK,
+            "Teleport to Lumbridge with spellbook.",
+            0,
+            "null",
+            218,
+            24,
+            12850,
+            lumbridgeTreePatchPoint,
+            Arrays.asList(
+                new ItemRequirement(
+                    ItemID.AIR_RUNE,
+                    3
+                ),
+                new ItemRequirement(
+                    ItemID.LAW_RUNE,
+                    1
+                ),
+                new ItemRequirement(
+                    ItemID.EARTH_RUNE,
+                    1
+                )
+            )
+        ));
 
         locations.add(lumbridgeTreeLocation);
     }
 
     private void setupTaverleyLocation()
     {
-        WorldPoint taverlyPatchPoint = new WorldPoint(2936, 3438, 0);
-
-        taverleyTreeLocation = new Location(FarmingHelperConfig::enumTreeTaverleyTeleport, config, "Taverley", false);
-
-        List<ItemRequirement> taverleyTreeTeleportItems = Arrays.asList(
-                new ItemRequirement(ItemID.AIR_RUNE, 3),
-                new ItemRequirement(ItemID.LAW_RUNE, 1),
-                new ItemRequirement(ItemID.WATER_RUNE, 1)
-        );
-        Location.Teleport taverleyTreeTeleport = taverleyTreeLocation.new Teleport(
-                "Falador_teleport",
-                Location.TeleportCategory.SPELLBOOK,
-                "Teleport to Falador with spellbook and run to Taverly.",
-                0,
-                "null",
-                218,
-                27,
-                11828,
-                taverlyPatchPoint,
-                taverleyTreeTeleportItems
+        WorldPoint taverlyPatchPoint = new WorldPoint(
+            2936,
+            3438,
+            0
         );
 
-        taverleyTreeLocation.addTeleportOption(taverleyTreeTeleport);
+        taverleyTreeLocation = new Location(
+            FarmingHelperConfig::enumTreeTaverleyTeleport,
+            config,
+            "Taverley",
+            false
+        );
+
+        taverleyTreeLocation.addTeleportOption(taverleyTreeLocation.new Teleport(
+            "Falador_teleport",
+            Location.TeleportCategory.SPELLBOOK,
+            "Teleport to Falador with spellbook and run to Taverly.",
+            0,
+            "null",
+            218,
+            27,
+            11828,
+            taverlyPatchPoint,
+            Arrays.asList(
+                new ItemRequirement(
+                    ItemID.AIR_RUNE,
+                    3
+                ),
+                new ItemRequirement(
+                    ItemID.LAW_RUNE,
+                    1
+                ),
+                new ItemRequirement(
+                    ItemID.WATER_RUNE,
+                    1
+                )
+            )
+        ));
 
         locations.add(taverleyTreeLocation);
     }
 
     private void setupVarrockLocation()
     {
-        WorldPoint varrockTreePatchPoint = new WorldPoint(3229, 3459, 0);
-
-        varrockTreeLocation = new Location(FarmingHelperConfig::enumTreeVarrockTeleport, config, "Varrock", false);
-
-        List<ItemRequirement> varrockTreeTeleportItems = Arrays.asList(
-                new ItemRequirement(ItemID.AIR_RUNE, 3),
-                new ItemRequirement(ItemID.LAW_RUNE, 1),
-                new ItemRequirement(ItemID.FIRE_RUNE, 1)
-        );
-        Location.Teleport varrockTreeTeleport = varrockTreeLocation.new Teleport(
-                "Varrock_teleport",
-                Location.TeleportCategory.SPELLBOOK,
-                "Teleport to Varrock with spellbook.",
-                0,
-                "null",
-                218,
-                21,
-                12853,
-                varrockTreePatchPoint,
-                varrockTreeTeleportItems
+        WorldPoint varrockTreePatchPoint = new WorldPoint(
+            3229,
+            3459,
+            0
         );
 
-        varrockTreeLocation.addTeleportOption(varrockTreeTeleport);
+        varrockTreeLocation = new Location(
+            FarmingHelperConfig::enumTreeVarrockTeleport,
+            config,
+            "Varrock",
+            false
+        );
+
+        varrockTreeLocation.addTeleportOption(varrockTreeLocation.new Teleport(
+            "Varrock_teleport",
+            Location.TeleportCategory.SPELLBOOK,
+            "Teleport to Varrock with spellbook.",
+            0,
+            "null",
+            218,
+            21,
+            12853,
+            varrockTreePatchPoint,
+            Arrays.asList(
+                new ItemRequirement(
+                    ItemID.AIR_RUNE,
+                    3
+                ),
+                new ItemRequirement(
+                    ItemID.LAW_RUNE,
+                    1
+                ),
+                new ItemRequirement(
+                    ItemID.FIRE_RUNE,
+                    1
+                )
+            )
+        ));
 
         locations.add(varrockTreeLocation);
     }

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/TreeRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/TreeRunItemAndLocation.java
@@ -146,6 +146,19 @@ public class TreeRunItemAndLocation extends ItemAndLocation
         );
 
         faladorTreeLocation.addTeleportOption(faladorTreeLocation.new Teleport(
+            "Portal_Nexus",
+            Location.TeleportCategory.PORTAL_NEXUS,
+            "Teleport to Falador with Portal Nexus.",
+            0,
+            "null",
+            17,
+            13,
+            11828,
+            faladorTreePatchPoint,
+            getHouseTeleportItemRequirements()
+        ));
+
+        faladorTreeLocation.addTeleportOption(faladorTreeLocation.new Teleport(
             "Falador_teleport",
             Location.TeleportCategory.SPELLBOOK,
             "Teleport to Falador with Spellbook and run to Falador park.",
@@ -255,6 +268,19 @@ public class TreeRunItemAndLocation extends ItemAndLocation
         );
 
         lumbridgeTreeLocation.addTeleportOption(lumbridgeTreeLocation.new Teleport(
+            "Portal_Nexus",
+            Location.TeleportCategory.PORTAL_NEXUS,
+            "Teleport to Lumbridge with Portal Nexus.",
+            0,
+            "null",
+            17,
+            13,
+            12850,
+            lumbridgeTreePatchPoint,
+            getHouseTeleportItemRequirements()
+        ));
+
+        lumbridgeTreeLocation.addTeleportOption(lumbridgeTreeLocation.new Teleport(
             "Lumbridge_teleport",
             Location.TeleportCategory.SPELLBOOK,
             "Teleport to Lumbridge with spellbook.",
@@ -299,6 +325,19 @@ public class TreeRunItemAndLocation extends ItemAndLocation
         );
 
         taverleyTreeLocation.addTeleportOption(taverleyTreeLocation.new Teleport(
+            "Portal_Nexus",
+            Location.TeleportCategory.PORTAL_NEXUS,
+            "Teleport to Falador with Portal Nexus and run to Taverly.",
+            0,
+            "null",
+            17,
+            13,
+            11828,
+            taverlyPatchPoint,
+            getHouseTeleportItemRequirements()
+        ));
+
+        taverleyTreeLocation.addTeleportOption(taverleyTreeLocation.new Teleport(
             "Falador_teleport",
             Location.TeleportCategory.SPELLBOOK,
             "Teleport to Falador with spellbook and run to Taverly.",
@@ -341,6 +380,19 @@ public class TreeRunItemAndLocation extends ItemAndLocation
             "Varrock",
             false
         );
+
+        varrockTreeLocation.addTeleportOption(varrockTreeLocation.new Teleport(
+            "Portal_Nexus",
+            Location.TeleportCategory.PORTAL_NEXUS,
+            "Teleport to Varrock with Portal Nexus.",
+            0,
+            "null",
+            17,
+            13,
+            12853,
+            varrockTreePatchPoint,
+            getHouseTeleportItemRequirements()
+        ));
 
         varrockTreeLocation.addTeleportOption(varrockTreeLocation.new Teleport(
             "Varrock_teleport",

--- a/src/main/java/com/farminghelper/speaax/StartStopJButton.java
+++ b/src/main/java/com/farminghelper/speaax/StartStopJButton.java
@@ -1,0 +1,24 @@
+package com.farminghelper.speaax;
+
+import javax.swing.*;
+import java.awt.*;
+import java.beans.ConstructorProperties;
+
+public class StartStopJButton extends JButton {
+    private String originalText;
+
+    public StartStopJButton(String text) {
+        super(text, null);
+
+        this.originalText = text;
+        this.setStartStopState(false);
+    }
+
+    public void setStartStopState(Boolean started)
+    {
+        String startOrStop = started ? "Stop " : "Start ";
+
+        this.setText(startOrStop.concat(this.originalText));
+        this.setBackground(started  ? Color.RED : Color.BLACK);
+    }
+}


### PR DESCRIPTION
Closes #5.

**There is currently a bug with the Camelot option not being selected for Catherby teleports, same with Falador for Taverly.** This is as on line 903 of `FarmingTeleportOverlay`, its currently using `location.getName()` instead of the name of the `Teleport`. Well, I think thats the issue anyway. Not sure what the easy solve on that is, without reading the location name from the Teleport and setting it against each Teleport... which isn't great.

- Refactored UI code.
- Adds a small UI refresh to add dynamic Start/Stop button states to align with the current run state.
- Adds the GitHub issues URL as the support link for the plugin.
- Adds the following teleport options:

**Herb teleport options to add:**
- Ardougne:
    - Portal Nexus (Ardougne)
- Catherby:
    - Portal Nexus (Camelot)
- Falador:
    - Portal Nexus (Falador)

**Tree teleport options to add:**
- Falador:
    - Portal Nexus (Falador)
- Lumbridge:
    - Portal Nexus (Lumbridge)
- Taverly:
    - Portal Nexus (Falador)
- Varrock:
    - Portal Nexus (Varrock)

**Fruit Tree teleport options to add:**
- Brimhaven:
    - Portal Nexus (Ardougne)
- Catherby:
    - Portal Nexus (Camelot)