### PR TITLE
Trees pay for protection

### DIFF
--- a/.idea/runConfigurations/RuneLite__macOS_.xml
+++ b/.idea/runConfigurations/RuneLite__macOS_.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="RuneLite (macOS)" type="Application" factoryName="Application">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-17" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="MAIN_CLASS_NAME" value="com.farminghelper.speaax.PluginLauncher" />
+    <module name="Farming-Helper.test" />
+    <option name="PROGRAM_PARAMETERS" value="--developer-mode" />
+    <option name="VM_PARAMETERS" value="-ea --add-opens=java.desktop/com.apple.eawt=ALL-UNNAMED" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/src/main/java/com/farminghelper/speaax/FarmingHelperConfig.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingHelperConfig.java
@@ -28,7 +28,7 @@ public interface FarmingHelperConfig extends Config
 		String name();
 	}
 	@ConfigItem(
-			position = 9,
+			position = 10,
 			keyName = "enumConfigHouseTele",
 			name = "House teleport",
 			description = "Desired way to teleport to house",

--- a/src/main/java/com/farminghelper/speaax/FarmingHelperConfig.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingHelperConfig.java
@@ -110,6 +110,15 @@ public interface FarmingHelperConfig extends Config
 	)
 	default boolean generalAllotment() { return false; }
 
+	@ConfigItem(
+		keyName = "booleanConfigPayForProtection",
+		name = "Pay for protection",
+		description = "Want a reminder to pay for protection? (This currently doesn't check for the required items, only prompts you to pay the farmer.)",
+		position = 9,
+		section = generalList
+	)
+	default boolean payForProtection() { return false; }
+
 
 	@ConfigSection(
 		name = "Herbs",

--- a/src/main/java/com/farminghelper/speaax/FarmingHelperConfig.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingHelperConfig.java
@@ -117,7 +117,7 @@ public interface FarmingHelperConfig extends Config
 		position = 9,
 		section = generalList
 	)
-	default boolean payForProtection() { return false; }
+	default boolean generalPayForProtection() { return false; }
 
 
 	@ConfigSection(

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -585,6 +585,8 @@ public class FarmingTeleportOverlay extends Overlay {
     }
 
     public Boolean treePatchDone = false;
+    public Boolean treePatchComposted = false;
+    public Boolean treePatchProtected = false;
     public Boolean patchComposted = false;
 
     public void treeSteps(Graphics2D graphics, Location.Teleport teleport) {
@@ -628,12 +630,12 @@ public class FarmingTeleportOverlay extends Overlay {
                 case REMOVE:
                     plugin.addTextToInfoBox("Pay to remove tree, or cut it down and clear the patch.");
                     if(!isInterfaceOpen(219, 1)) {
-                        highlightNpc(graphics, "Heskel", leftClickColorWithAlpha); //Falador
-                        highlightNpc(graphics, "Rosie", leftClickColorWithAlpha); //Farming Guild
-                        highlightNpc(graphics, "Prissy Scilla", leftClickColorWithAlpha); //Gnome Stronghold
-                        highlightNpc(graphics, "Fayeth", leftClickColorWithAlpha); //Lumbridge
-                        highlightNpc(graphics, "Alain", leftClickColorWithAlpha); //Taverly
-                        highlightNpc(graphics, "Treznor", leftClickColorWithAlpha); //Varrock
+                        highlightNpc(graphics, "Heskel", leftClickColorWithAlpha); // Falador
+                        highlightNpc(graphics, "Rosie", leftClickColorWithAlpha); // Farming Guild
+                        highlightNpc(graphics, "Prissy Scilla", leftClickColorWithAlpha); // Gnome Stronghold
+                        highlightNpc(graphics, "Fayeth", leftClickColorWithAlpha); // Lumbridge
+                        highlightNpc(graphics, "Alain", leftClickColorWithAlpha); // Taverly
+                        highlightNpc(graphics, "Treznor", leftClickColorWithAlpha); // Varrock
                     }
                     else {
                         Widget widget = client.getWidget(219, 1);
@@ -644,18 +646,46 @@ public class FarmingTeleportOverlay extends Overlay {
                     plugin.addTextToInfoBox("UNKNOWN state: Try to do something with the tree patch to change its state.");
                     break;
                 case GROWING:
-                    plugin.addTextToInfoBox("Use Compost on patch.");
-                    if(isItemInInventory(selectedCompostID())) {
-                        highlightTreePatches(graphics, highlightUseItemWithAlpha);
-                        itemHighlight(graphics, selectedCompostID(), highlightUseItemWithAlpha);
+                    if (!treePatchComposted) {
+                        plugin.addTextToInfoBox("Use Compost on patch.");
+
+                        if (isItemInInventory(selectedCompostID())) {
+                            highlightTreePatches(graphics, highlightUseItemWithAlpha);
+                            itemHighlight(graphics, selectedCompostID(), highlightUseItemWithAlpha);
+                        } else {
+                            withdrawCompost(graphics);
+                        }
+
+                        if (isItComposted(plugin.getLastMessage())) {
+                            treePatchComposted = true;
+                        } else {
+                            // If the patch is yet to be composted, only show the compost step at this time, until it has been composted
+                            break;
+                        }
                     }
-                    else {
-                        withdrawCompost(graphics);
+
+                    if (config.payForProtection() && !treePatchProtected) {
+                        plugin.addTextToInfoBox("Pay to protect the patch.");
+
+                        if (! isInterfaceOpen(219, 1)) {
+                            highlightNpc(graphics, "Heskel", leftClickColorWithAlpha); // Falador
+                            highlightNpc(graphics, "Rosie", leftClickColorWithAlpha); // Farming Guild
+                            highlightNpc(graphics, "Prissy Scilla", leftClickColorWithAlpha); // Gnome Stronghold
+                            highlightNpc(graphics, "Fayeth", leftClickColorWithAlpha); // Lumbridge
+                            highlightNpc(graphics, "Alain", leftClickColorWithAlpha); // Taverly
+                            highlightNpc(graphics, "Treznor", leftClickColorWithAlpha); // Varrock
+                        } else {
+                            Widget widget = client.getWidget(219, 1);
+                            highlightDynamicComponent(graphics, widget, 1, leftClickColorWithAlpha);
+                            treePatchProtected = true;
+                        }
                     }
-                    if (isItComposted(plugin.getLastMessage())) {
+
+                    if (treePatchComposted && (!config.payForProtection() || (config.payForProtection() && treePatchProtected))) {
                         currentHerbCase = 1;
                         treePatchDone = true;
                     }
+
                     break;
             }
         }
@@ -923,7 +953,7 @@ public class FarmingTeleportOverlay extends Overlay {
                             case 2:
                                 if (!isInterfaceOpen(17, 0)) {
                                     // TODO: Need to figure out what the game object ID of the Spirit Tree is
-                                    List<Integer> spiritTreeIds = getGameObjectIdsByName("Spirit Tree");
+                                    List<Integer> spiritTreeIds = getGameObjectIdsByName("Spirit tree");
                                     for (Integer objectId : spiritTreeIds) {
                                         gameObjectOverlay(objectId, leftClickColorWithAlpha).render(graphics);
                                     }
@@ -1087,6 +1117,8 @@ public class FarmingTeleportOverlay extends Overlay {
                     herbRunIndex++;
                     patchComposted = false;
                     treePatchDone = false;
+                    treePatchComposted = false;
+                    treePatchProtected = false;
                 }
             }
             if (fruitTreeRun) {

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -411,9 +411,44 @@ public class FarmingTeleportOverlay extends Overlay {
             withdrawCompost(graphics);
         }
     }
+
+    public void highlightFarmers(Graphics2D graphics, List<String> farmers)
+    {
+        if (! isInterfaceOpen(219, 1)) {
+            for (String farmer : farmers) {
+                highlightNpc(graphics, farmer);
+            }
+        } else {
+            Widget widget = client.getWidget(219, 1);
+            highlightDynamicComponent(graphics, widget, 1);
         }
     }
 
+    public void highlightTreeFarmers(Graphics2D graphics)
+    {
+        highlightFarmers(graphics, Arrays.asList(
+            "Alain",         // Taverly
+            "Fayeth",        // Lumbridge
+            "Heskel",        // Falador
+            "Prissy Scilla", // Gnome Stronghold
+            "Rosie",         // Farming Guild
+            "Treznor"        // Varrock
+        ));
+    }
+
+    public void highlightFruitTreeFarmers(Graphics2D graphics)
+    {
+        highlightFarmers(graphics, Arrays.asList(
+            "Bolongo", // Gnome Stronghold
+            "Ellena",  // Catherby
+            "Garth",   // Brimhaven
+            "Gileth",  // Tree Gnome Village
+            "Liliwen", // Lletya
+            "Nikkie"   // Farming Guild
+        ));
+    }
+
+    public void highlightHerbSeeds(Graphics2D graphics) {
         List<Integer> herbSeedIds = farmingHelperOverlay.getHerbSeedIds();
         for (Integer seedId : herbSeedIds) {
             itemHighlight(graphics, seedId);
@@ -618,8 +653,6 @@ public class FarmingTeleportOverlay extends Overlay {
     }
 
     public Boolean treePatchDone = false;
-    public Boolean treePatchComposted = false;
-    public Boolean treePatchProtected = false;
 
     public void treeSteps(Graphics2D graphics, Location.Teleport teleport) {
         int currentRegionId = client.getLocalPlayer().getWorldLocation().getRegionID();
@@ -661,64 +694,32 @@ public class FarmingTeleportOverlay extends Overlay {
                     break;
                 case REMOVE:
                     plugin.addTextToInfoBox("Pay to remove tree, or cut it down and clear the patch.");
-                    if(!isInterfaceOpen(219, 1)) {
-                        highlightNpc(graphics, "Heskel", leftClickColorWithAlpha); // Falador
-                        highlightNpc(graphics, "Rosie", leftClickColorWithAlpha); // Farming Guild
-                        highlightNpc(graphics, "Prissy Scilla", leftClickColorWithAlpha); // Gnome Stronghold
-                        highlightNpc(graphics, "Fayeth", leftClickColorWithAlpha); // Lumbridge
-                        highlightNpc(graphics, "Alain", leftClickColorWithAlpha); // Taverly
-                        highlightNpc(graphics, "Treznor", leftClickColorWithAlpha); // Varrock
-                    }
-                    else {
-                        Widget widget = client.getWidget(219, 1);
-                        highlightDynamicComponent(graphics, widget, 1, leftClickColorWithAlpha);
-                    }
+
+                    highlightTreeFarmers(graphics);
+
                     break;
                 case UNKNOWN:
                     plugin.addTextToInfoBox("UNKNOWN state: Try to do something with the tree patch to change its state.");
                     break;
                 case GROWING:
-                    if (!treePatchComposted) {
-                        plugin.addTextToInfoBox("Use Compost on patch.");
-
-                        if (isItemInInventory(selectedCompostID())) {
-                            highlightTreePatches(graphics, highlightUseItemWithAlpha);
-                            itemHighlight(graphics, selectedCompostID(), highlightUseItemWithAlpha);
-                        } else {
-                            withdrawCompost(graphics);
-                        }
-
-                        if (isItComposted(plugin.getLastMessage())) {
-                            treePatchComposted = true;
-                        } else {
-                            // If the patch is yet to be composted, only show the compost step at this time, until it has been composted
-                            break;
-                        }
-                    }
-
-                    if (config.payForProtection() && !treePatchProtected) {
+                    if (config.generalPayForProtection()) {
                         plugin.addTextToInfoBox("Pay to protect the patch.");
 
-                        if (! isInterfaceOpen(219, 1)) {
-                            highlightNpc(graphics, "Heskel", leftClickColorWithAlpha); // Falador
-                            highlightNpc(graphics, "Rosie", leftClickColorWithAlpha); // Farming Guild
-                            highlightNpc(graphics, "Prissy Scilla", leftClickColorWithAlpha); // Gnome Stronghold
-                            highlightNpc(graphics, "Fayeth", leftClickColorWithAlpha); // Lumbridge
-                            highlightNpc(graphics, "Alain", leftClickColorWithAlpha); // Taverly
-                            highlightNpc(graphics, "Treznor", leftClickColorWithAlpha); // Varrock
-                        } else {
-                            Widget widget = client.getWidget(219, 1);
-                            highlightDynamicComponent(graphics, widget, 1, leftClickColorWithAlpha);
-                        }
+                        highlightTreeFarmers(graphics);
 
                         if (patchIsProtected()) {
-                            treePatchProtected = true;
+                            currentHerbCase = 1;
+                            treePatchDone = true;
                         }
-                    }
+                    } else {
+                        plugin.addTextToInfoBox("Use Compost on patch.");
 
-                    if (treePatchComposted && (!config.payForProtection() || (config.payForProtection() && treePatchProtected))) {
-                        currentHerbCase = 1;
-                        treePatchDone = true;
+                        highlightCompost(graphics);
+
+                        if (patchIsComposted()) {
+                            currentHerbCase = 1;
+                            treePatchDone = true;
+                        }
                     }
 
                     break;
@@ -727,8 +728,6 @@ public class FarmingTeleportOverlay extends Overlay {
     }
 
     public Boolean fruitTreePatchDone = false;
-    public Boolean fruitTreePatchComposted = false;
-    public Boolean fruitTreePatchProtected = false;
 
     public void fruitTreeSteps(Graphics2D graphics, Location.Teleport teleport) {
         int currentRegionId = client.getLocalPlayer().getWorldLocation().getRegionID();
@@ -771,64 +770,32 @@ public class FarmingTeleportOverlay extends Overlay {
                     break;
                 case REMOVE:
                     plugin.addTextToInfoBox("Pay to remove fruit tree, or cut it down and clear the patch.");
-                    if(!isInterfaceOpen(219, 1)) {
-                        highlightNpc(graphics, "Garth", leftClickColorWithAlpha); // Brimhaven
-                        highlightNpc(graphics, "Ellena", leftClickColorWithAlpha); // Catherby
-                        highlightNpc(graphics, "Nikkie", leftClickColorWithAlpha); // Farming Guild
-                        highlightNpc(graphics, "Bolongo", leftClickColorWithAlpha); // Gnome Stronghold
-                        highlightNpc(graphics, "Liliwen", leftClickColorWithAlpha); // Lletya
-                        highlightNpc(graphics, "Gileth", leftClickColorWithAlpha); // Tree Gnome Village
-                    }
-                    else {
-                        Widget widget = client.getWidget(219, 1);
-                        highlightDynamicComponent(graphics, widget, 1, leftClickColorWithAlpha);
-                    }
+
+                    highlightFruitTreeFarmers(graphics);
+
                     break;
                 case UNKNOWN:
                     plugin.addTextToInfoBox("UNKNOWN state: Try to do something with the tree patch to change its state.");
                     break;
                 case GROWING:
-                    if (!fruitTreePatchComposted) {
-                        plugin.addTextToInfoBox("Use Compost on patch.");
-
-                        if (isItemInInventory(selectedCompostID())) {
-                            highlightFruitTreePatches(graphics, highlightUseItemWithAlpha);
-                            itemHighlight(graphics, selectedCompostID(), highlightUseItemWithAlpha);
-                        } else {
-                            withdrawCompost(graphics);
-                        }
-
-                        if (isItComposted(plugin.getLastMessage())) {
-                            fruitTreePatchComposted = true;
-                        } else {
-                            // If the patch is yet to be composted, only show the compost step at this time, until it has been composted
-                            break;
-                        }
-                    }
-
-                    if (config.payForProtection() && !fruitTreePatchProtected) {
+                    if (config.generalPayForProtection()) {
                         plugin.addTextToInfoBox("Pay to protect the patch.");
 
-                        if (! isInterfaceOpen(219, 1)) {
-                            highlightNpc(graphics, "Garth", leftClickColorWithAlpha); // Brimhaven
-                            highlightNpc(graphics, "Ellena", leftClickColorWithAlpha); // Catherby
-                            highlightNpc(graphics, "Nikkie", leftClickColorWithAlpha); // Farming Guild
-                            highlightNpc(graphics, "Bolongo", leftClickColorWithAlpha); // Gnome Stronghold
-                            highlightNpc(graphics, "Liliwen", leftClickColorWithAlpha); // Lletya
-                            highlightNpc(graphics, "Gileth", leftClickColorWithAlpha); // Tree Gnome Village
-                        } else {
-                            Widget widget = client.getWidget(219, 1);
-                            highlightDynamicComponent(graphics, widget, 1, leftClickColorWithAlpha);
-                        }
+                        highlightFruitTreeFarmers(graphics);
 
                         if (patchIsProtected()) {
-                            fruitTreePatchProtected = true;
+                            currentHerbCase = 1;
+                            fruitTreePatchDone = true;
                         }
-                    }
+                    } else {
+                        plugin.addTextToInfoBox("Use Compost on patch.");
 
-                    if (fruitTreePatchComposted && (!config.payForProtection() || (config.payForProtection() && fruitTreePatchProtected))) {
-                        currentHerbCase = 1;
-                        fruitTreePatchDone = true;
+                        highlightCompost(graphics);
+
+                        if (patchIsComposted()) {
+                            currentHerbCase = 1;
+                            fruitTreePatchDone = true;
+                        }
                     }
 
                     break;
@@ -1176,8 +1143,6 @@ public class FarmingTeleportOverlay extends Overlay {
                     isAtDestination = false;
                     herbRunIndex++;
                     treePatchDone = false;
-                    treePatchComposted = false;
-                    treePatchProtected = false;
                 }
             }
             if (fruitTreeRun) {
@@ -1187,8 +1152,6 @@ public class FarmingTeleportOverlay extends Overlay {
                     isAtDestination = false;
                     herbRunIndex++;
                     fruitTreePatchDone = false;
-                    fruitTreePatchComposted = false;
-                    fruitTreePatchProtected = false;
                 }
             }
         }

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -186,14 +186,14 @@ public class FarmingTeleportOverlay extends Overlay {
         return -1; // Return -1 if the specified text is not found
     }
 
-    public void highlightDynamicComponent(Graphics2D graphics, Widget widget, int dynamicChildIndex, Color color) {
+    public void highlightDynamicComponent(Graphics2D graphics, Widget widget, int dynamicChildIndex) {
         if (widget != null) {
             Widget[] dynamicChildren = widget.getDynamicChildren();
             if (dynamicChildren != null && dynamicChildIndex >= 0 && dynamicChildIndex < dynamicChildren.length) {
                 Widget dynamicChild = dynamicChildren[dynamicChildIndex];
                 if (dynamicChild != null) {
                     Rectangle bounds = dynamicChild.getBounds();
-                    graphics.setColor(color);
+                    graphics.setColor(leftClickColorWithAlpha);
                     //graphics.draw(bounds);
                     graphics.fill(bounds);
                 }
@@ -201,7 +201,7 @@ public class FarmingTeleportOverlay extends Overlay {
         }
     }
 
-    public void itemHighlight(Graphics2D graphics, int itemID, Color color) {
+    public void itemHighlight(Graphics2D graphics, int itemID) {
         ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
 
         if (inventory != null) {
@@ -214,7 +214,7 @@ public class FarmingTeleportOverlay extends Overlay {
                 if (item.getId() == itemID) {
                     Widget itemWidget = inventoryWidget.getChild(i);
                     Rectangle bounds = itemWidget.getBounds();
-                    graphics.setColor(color);
+                    graphics.setColor(highlightUseItemWithAlpha);
                     graphics.draw(bounds);
                     graphics.fill(bounds);
                 }
@@ -251,7 +251,7 @@ public class FarmingTeleportOverlay extends Overlay {
         }
     }
 
-    public Overlay gameObjectOverlay(int objectId, Color color) {
+    public Overlay gameObjectOverlay(int objectId) {
         return new Overlay() {
             @Override
             public Dimension render(Graphics2D graphics) {
@@ -259,7 +259,7 @@ public class FarmingTeleportOverlay extends Overlay {
                 if (client != null) {
                     List<GameObject> gameObjects = findGameObjectsByID(objectId);
                     for (GameObject gameObject : gameObjects) {
-                        drawGameObjectClickbox(graphics, gameObject, color);
+                        drawGameObjectClickbox(graphics, gameObject, highlightUseItemWithAlpha);
                     }
                 }
                 return null;
@@ -337,7 +337,7 @@ public class FarmingTeleportOverlay extends Overlay {
         }
     }
 
-    public void highlightNpc(Graphics2D graphics, String npcName, Color color) {
+    public void highlightNpc(Graphics2D graphics, String npcName) {
         List<NPC> npcs = client.getNpcs();
 
         if (npcs != null) {
@@ -346,7 +346,7 @@ public class FarmingTeleportOverlay extends Overlay {
                     Polygon tilePolygon = npc.getCanvasTilePoly();
 
                     if (tilePolygon != null) {
-                        graphics.setColor(color);
+                        graphics.setColor(leftClickColorWithAlpha);
                         graphics.draw(tilePolygon);
                         //graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue()));
                         graphics.fill(tilePolygon);
@@ -373,66 +373,77 @@ public class FarmingTeleportOverlay extends Overlay {
         }
     }
 
-    public void highlightHerbPatches(Graphics2D graphics, Color color) {
-        List<Integer> herbPatchIds = farmingHelperOverlay.getHerbPatchIds();
-        for (Integer patchId : herbPatchIds) {
-            gameObjectOverlay(patchId, color).render(graphics);
+    public void highlightHerbPatches(Graphics2D graphics)
+    {
+        for (Integer patchId : farmingHelperOverlay.getHerbPatchIds()) {
+            gameObjectOverlay(patchId).render(graphics);
         }
     }
 
-    public void highlightFlowerPatches(Graphics2D graphics, Color color) {
-        List<Integer> flowerPatchIds = farmingHelperOverlay.getFlowerPatchIds();
-        for (Integer patchId : flowerPatchIds) {
-            gameObjectOverlay(patchId, color).render(graphics);
+    public void highlightFlowerPatches(Graphics2D graphics)
+    {
+        for (Integer patchId : farmingHelperOverlay.getFlowerPatchIds()) {
+            gameObjectOverlay(patchId).render(graphics);
         }
     }
 
-    public void highlightTreePatches(Graphics2D graphics, Color color) {
-        List<Integer> treePatchIds = farmingHelperOverlay.getTreePatchIds();
-        for (Integer patchId : treePatchIds) {
-            gameObjectOverlay(patchId, color).render(graphics);
+    public void highlightTreePatches(Graphics2D graphics)
+    {
+        for (Integer patchId : farmingHelperOverlay.getTreePatchIds()) {
+            gameObjectOverlay(patchId).render(graphics);
         }
     }
 
-    public void highlightFruitTreePatches(Graphics2D graphics, Color color) {
-        List<Integer> fruitTreePatchIds = farmingHelperOverlay.getFruitTreePatchIds();
-        for (Integer patchId : fruitTreePatchIds) {
-            gameObjectOverlay(patchId, color).render(graphics);
+    public void highlightFruitTreePatches(Graphics2D graphics)
+    {
+        for (Integer patchId : farmingHelperOverlay.getFruitTreePatchIds()) {
+            gameObjectOverlay(patchId).render(graphics);
         }
     }
 
-    public void highlightHerbSeeds(Graphics2D graphics, Color color) {
+    public void highlightCompost(Graphics2D graphics)
+    {
+        if (isItemInInventory(selectedCompostID())) {
+            highlightTreePatches(graphics);
+            itemHighlight(graphics, selectedCompostID());
+        } else {
+            withdrawCompost(graphics);
+        }
+    }
+        }
+    }
+
         List<Integer> herbSeedIds = farmingHelperOverlay.getHerbSeedIds();
         for (Integer seedId : herbSeedIds) {
-            itemHighlight(graphics, seedId, color);
+            itemHighlight(graphics, seedId);
         }
     }
 
-    public void highlightTreeSapling(Graphics2D graphics, Color color) {
+    public void highlightTreeSapling(Graphics2D graphics) {
         List<Integer> treeSaplingIds = farmingHelperOverlay.getTreeSaplingIds();
         for (Integer seedId : treeSaplingIds) {
-            itemHighlight(graphics, seedId, color);
+            itemHighlight(graphics, seedId);
         }
     }
 
-    public void highlightFruitTreeSapling(Graphics2D graphics, Color color) {
+    public void highlightFruitTreeSapling(Graphics2D graphics) {
         List<Integer> fruitTreeSaplingIds = farmingHelperOverlay.getFruitTreeSaplingIds();
         for (Integer seedId : fruitTreeSaplingIds) {
-            itemHighlight(graphics, seedId, color);
+            itemHighlight(graphics, seedId);
         }
     }
 
-    public void highlightTeleportCrystal(Graphics2D graphics, Color color) {
+    public void highlightTeleportCrystal(Graphics2D graphics) {
         List<Integer> teleportCrystalIds = farmingHelperOverlay.getTeleportCrystalIdsIds();
         for (Integer seedId : teleportCrystalIds) {
-            itemHighlight(graphics, seedId, color);
+            itemHighlight(graphics, seedId);
         }
     }
 
-    public void highlightSkillsNecklace(Graphics2D graphics, Color color) {
+    public void highlightSkillsNecklace(Graphics2D graphics) {
         List<Integer> skillsNecklaceIds = farmingHelperOverlay.getSkillsNecklaceIdsIds();
         for (Integer seedId : skillsNecklaceIds) {
-            itemHighlight(graphics, seedId, color);
+            itemHighlight(graphics, seedId);
         }
     }
 
@@ -474,7 +485,7 @@ public class FarmingTeleportOverlay extends Overlay {
     public void withdrawCompost (Graphics2D graphics) {
         plugin.addTextToInfoBox("Withdraw compost from Tool Leprechaun");
         if(!isInterfaceOpen(125,0)) {
-            highlightNpc(graphics, "Tool Leprechaun", leftClickColorWithAlpha);
+            highlightNpc(graphics, "Tool Leprechaun");
         }
         else {
             if (selectedCompostID() == ItemID.COMPOST) {
@@ -516,31 +527,31 @@ public class FarmingTeleportOverlay extends Overlay {
         if (!areaCheck.isPlayerWithinArea(teleport.getPoint(), 15))
         {
             //should be replaced with a pathing system, pointing arrow or something else eventually
-            highlightHerbPatches(graphics, leftClickColorWithAlpha);
+            highlightHerbPatches(graphics);
         }
         else {
             switch (plantState) {
                 case HARVESTABLE:
                     plugin.addTextToInfoBox("Harvest Herbs.");
-                    highlightHerbPatches(graphics, leftClickColorWithAlpha);
+                    highlightHerbPatches(graphics);
                     break;
                 case PLANT:
                     plugin.addTextToInfoBox("Use Herb seed on patch.");
-                    highlightHerbPatches(graphics, highlightUseItemWithAlpha);
-                    highlightHerbSeeds(graphics, highlightUseItemWithAlpha);
+                    highlightHerbPatches(graphics);
+                    highlightHerbSeeds(graphics);
                     break;
                 case DEAD:
                     plugin.addTextToInfoBox("Clear the dead herb patch.");
-                    highlightHerbPatches(graphics, leftClickColorWithAlpha);
+                    highlightHerbPatches(graphics);
                     break;
                 case DISEASED:
                     plugin.addTextToInfoBox("Use Plant cure on herb patch. Buy at GE or in farming guild/catherby, and store at Tool Leprechaun for easy access.");
-                    highlightHerbPatches(graphics, leftClickColorWithAlpha);
-                    itemHighlight(graphics, ItemID.PLANT_CURE, highlightUseItemWithAlpha);
+                    highlightHerbPatches(graphics);
+                    itemHighlight(graphics, ItemID.PLANT_CURE);
                     break;
                 case WEEDS:
                     plugin.addTextToInfoBox("Rake the herb patch.");
-                    highlightHerbPatches(graphics, leftClickColorWithAlpha);
+                    highlightHerbPatches(graphics);
                     break;
                 case GROWING:
                     plugin.addTextToInfoBox("Use Compost on patch.");
@@ -578,20 +589,20 @@ public class FarmingTeleportOverlay extends Overlay {
             switch (plantState) {
                 case HARVESTABLE:
                     plugin.addTextToInfoBox("Harvest Limwurt root.");
-                    highlightFlowerPatches(graphics, leftClickColorWithAlpha);
+                    highlightFlowerPatches(graphics);
                     break;
                 case WEEDS:
                     plugin.addTextToInfoBox("Rake the flower patch.");
-                    highlightFlowerPatches(graphics, leftClickColorWithAlpha);
+                    highlightFlowerPatches(graphics);
                     break;
                 case DEAD:
                     plugin.addTextToInfoBox("Clear the dead flower patch.");
-                    highlightFlowerPatches(graphics, leftClickColorWithAlpha);
+                    highlightFlowerPatches(graphics);
                     break;
                 case PLANT:
                     plugin.addTextToInfoBox("Use Limwurt seed on the patch.");
-                    highlightFlowerPatches(graphics, highlightUseItemWithAlpha);
-                    itemHighlight(graphics, ItemID.LIMPWURT_SEED, highlightUseItemWithAlpha);
+                    highlightFlowerPatches(graphics);
+                    itemHighlight(graphics, ItemID.LIMPWURT_SEED);
                     break;
                 case GROWING:
                     plugin.addTextToInfoBox("Use Compost on patch.");
@@ -632,30 +643,30 @@ public class FarmingTeleportOverlay extends Overlay {
         if (!areaCheck.isPlayerWithinArea(teleport.getPoint(), 15))
         {
             //should be replaced with a pathing system, pointing arrow or something else eventually
-            highlightTreePatches(graphics, leftClickColorWithAlpha);
+            highlightTreePatches(graphics);
         }
         else {
             switch (plantState) {
                 case HEALTHY:
                     plugin.addTextToInfoBox("Check tree health.");
-                    highlightTreePatches(graphics, leftClickColorWithAlpha);
+                    highlightTreePatches(graphics);
                     break;
                 case WEEDS:
                     plugin.addTextToInfoBox("Rake the tree patch.");
-                    highlightTreePatches(graphics, leftClickColorWithAlpha);
+                    highlightTreePatches(graphics);
                     break;
                 case DEAD:
                     plugin.addTextToInfoBox("Clear the dead tree patch.");
-                    highlightTreePatches(graphics, leftClickColorWithAlpha);
+                    highlightTreePatches(graphics);
                     break;
                 case PLANT:
                     plugin.addTextToInfoBox("Use Sapling on the patch.");
-                    highlightTreePatches(graphics, highlightUseItemWithAlpha);
-                    highlightTreeSapling(graphics, highlightUseItemWithAlpha);
+                    highlightTreePatches(graphics);
+                    highlightTreeSapling(graphics);
                     break;
                 case DISEASED:
                     plugin.addTextToInfoBox("Prune the tree patch patch.");
-                    highlightTreePatches(graphics, highlightUseItemWithAlpha);
+                    highlightTreePatches(graphics);
                     break;
                 case REMOVE:
                     plugin.addTextToInfoBox("Pay to remove tree, or cut it down and clear the patch.");
@@ -743,29 +754,29 @@ public class FarmingTeleportOverlay extends Overlay {
         }
         if (!areaCheck.isPlayerWithinArea(teleport.getPoint(), 15)) {
             //should be replaced with a pathing system, point arrow or something else eventually
-            highlightFruitTreePatches(graphics, leftClickColorWithAlpha);
+            highlightFruitTreePatches(graphics);
         } else {
             switch (plantState) {
                 case HEALTHY:
                     plugin.addTextToInfoBox("Check Fruit tree health.");
-                    highlightFruitTreePatches(graphics, leftClickColorWithAlpha);
+                    highlightFruitTreePatches(graphics);
                     break;
                 case WEEDS:
                     plugin.addTextToInfoBox("Rake the fruit tree patch.");
-                    highlightFruitTreePatches(graphics, leftClickColorWithAlpha);
+                    highlightFruitTreePatches(graphics);
                     break;
                 case DEAD:
                     plugin.addTextToInfoBox("Clear the dead fruit tree patch.");
-                    highlightFruitTreePatches(graphics, leftClickColorWithAlpha);
+                    highlightFruitTreePatches(graphics);
                     break;
                 case PLANT:
                     plugin.addTextToInfoBox("Use Sapling on the patch.");
-                    highlightFruitTreePatches(graphics, highlightUseItemWithAlpha);
-                    highlightFruitTreeSapling(graphics, highlightUseItemWithAlpha);
+                    highlightFruitTreePatches(graphics);
+                    highlightFruitTreeSapling(graphics);
                     break;
                 case DISEASED:
                     plugin.addTextToInfoBox("Prune the fruit tree patch.");
-                    highlightFruitTreePatches(graphics, leftClickColorWithAlpha);
+                    highlightFruitTreePatches(graphics);
                     break;
                 case REMOVE:
                     plugin.addTextToInfoBox("Pay to remove fruit tree, or cut it down and clear the patch.");
@@ -885,19 +896,19 @@ public class FarmingTeleportOverlay extends Overlay {
                 }
             case Teleport_To_House:
                 inHouseCheck();
-                itemHighlight(graphics, ItemID.TELEPORT_TO_HOUSE, leftClickColorWithAlpha);
+                itemHighlight(graphics, ItemID.TELEPORT_TO_HOUSE);
                 break;
             case Construction_cape:
                 inHouseCheck();
-                itemHighlight(graphics, ItemID.CONSTRUCT_CAPE, rightClickColorWithAlpha);
+                itemHighlight(graphics, ItemID.CONSTRUCT_CAPE);
                 break;
             case Construction_cape_t:
                 inHouseCheck();
-                itemHighlight(graphics, ItemID.CONSTRUCT_CAPET, rightClickColorWithAlpha);
+                itemHighlight(graphics, ItemID.CONSTRUCT_CAPET);
                 break;
             case Max_cape:
                 inHouseCheck();
-                itemHighlight(graphics, ItemID.MAX_CAPE, rightClickColorWithAlpha);
+                itemHighlight(graphics, ItemID.MAX_CAPE);
                 break;
         }
     }
@@ -928,13 +939,13 @@ public class FarmingTeleportOverlay extends Overlay {
                     case ITEM:
                         if (teleport.getInterfaceGroupId() != 0) {
                             if (!isInterfaceOpen(teleport.getInterfaceGroupId(), teleport.getInterfaceChildId())) {
-                                itemHighlight(graphics, teleport.getId(), rightClickColorWithAlpha);
+                                itemHighlight(graphics, teleport.getId());
                                 if (!teleport.getRightClickOption().equals("null")) {
                                     highlightRightClickOption(graphics, teleport.getRightClickOption());
                                 }
                             } else {
                                 Widget widget = client.getWidget(teleport.getInterfaceGroupId(), teleport.getInterfaceChildId());
-                                highlightDynamicComponent(graphics, widget, 1, leftClickColorWithAlpha);
+                                highlightDynamicComponent(graphics, widget, 1);
                             }
                             if (currentRegionId == teleport.getRegionId()) {
                                 currentTeleportCase = 1;
@@ -946,30 +957,30 @@ public class FarmingTeleportOverlay extends Overlay {
                             }
                         } else {
                             if (!teleport.getRightClickOption().equals("null")) {
-                                itemHighlight(graphics, teleport.getId(), rightClickColorWithAlpha);
+                                itemHighlight(graphics, teleport.getId());
                                 highlightRightClickOption(graphics, teleport.getRightClickOption());
                             } else {
                                 if(teleport.getId() == ItemID.TELEPORT_CRYSTAL_1) {
-                                    highlightTeleportCrystal(graphics, leftClickColorWithAlpha);
+                                    highlightTeleportCrystal(graphics);
                                 }
                                 if(teleport.getId() == ItemID.SKILLS_NECKLACE1) {
                                     String index = location.getName();
                                     if(Objects.equals(index, "Ardougne")) {
-                                        highlightSkillsNecklace(graphics, leftClickColorWithAlpha);
+                                        highlightSkillsNecklace(graphics);
                                         highlightRightClickOption(graphics, "Rub");
                                         Widget widget = client.getWidget(187, 3);
-                                        highlightDynamicComponent(graphics, widget, 0, leftClickColorWithAlpha);
+                                        highlightDynamicComponent(graphics, widget, 0);
                                     }
                                     if(Objects.equals(index, "Farming Guild")) {
-                                        highlightSkillsNecklace(graphics, leftClickColorWithAlpha);
+                                        highlightSkillsNecklace(graphics);
                                         highlightRightClickOption(graphics, "Rub");
                                         Widget widget = client.getWidget(187, 3);
-                                        highlightDynamicComponent(graphics, widget, 5, leftClickColorWithAlpha);
+                                        highlightDynamicComponent(graphics, widget, 5);
                                     }
                                 }
 
                                 else {
-                                    itemHighlight(graphics, teleport.getId(), leftClickColorWithAlpha);
+                                    itemHighlight(graphics, teleport.getId());
                                 }
                             }
                             if (currentRegionId == teleport.getRegionId()) {
@@ -991,13 +1002,13 @@ public class FarmingTeleportOverlay extends Overlay {
                                 if (!isInterfaceOpen(17, 0)) {
                                     List<Integer> portalNexusIds = getGameObjectIdsByName("Portal Nexus");
                                     for (Integer objectId : portalNexusIds) {
-                                        gameObjectOverlay(objectId, leftClickColorWithAlpha).render(graphics);
+                                        gameObjectOverlay(objectId).render(graphics);
                                     }
                                 } else {
                                     // TODO: The location doesn't always align with the Teleport option, meaning it won't be highlighted, such as using the Camelot teleport for Catherby
                                     Widget widget = client.getWidget(17, 13);
                                     int index = getChildIndexPN(location.getName());
-                                    highlightDynamicComponent(graphics, widget, index, leftClickColorWithAlpha);
+                                    highlightDynamicComponent(graphics, widget, index);
                                 }
                                 if (currentRegionId == teleport.getRegionId()) {
                                     currentTeleportCase = 1;
@@ -1015,13 +1026,13 @@ public class FarmingTeleportOverlay extends Overlay {
                             List<Integer> spiritTreeIds = Arrays.asList(1293, 1294, 1295, 8355, 29227, 29229, 37329, 40778);
 
                             for (Integer objectId : spiritTreeIds) {
-                                gameObjectOverlay(objectId, leftClickColorWithAlpha).render(graphics);
+                                gameObjectOverlay(objectId).render(graphics);
                             }
                         } else {
                             // TODO: The location doesn't always align with the Teleport option, meaning it won't be highlighted, such as using the Camelot teleport for Catherby
                             int index = getChildIndexPN(location.getName());
                             Widget widget = client.getWidget(187, 3);
-                            highlightDynamicComponent(graphics, widget, index, leftClickColorWithAlpha);
+                            highlightDynamicComponent(graphics, widget, index);
                         }
 
                         if (currentRegionId == teleport.getRegionId()) {
@@ -1045,12 +1056,12 @@ public class FarmingTeleportOverlay extends Overlay {
 
                                 if (!isInterfaceOpen(590, 0)) {
                                     for (int id : jewelleryBoxIds) {
-                                        gameObjectOverlay(id, leftClickColorWithAlpha).render(graphics);
+                                        gameObjectOverlay(id).render(graphics);
                                     }
-                                    gameObjectOverlay(teleport.getId(), leftClickColorWithAlpha).render(graphics);
+                                    gameObjectOverlay(teleport.getId()).render(graphics);
                                 } else {
                                     Widget widget = client.getWidget(590, 5);
-                                    highlightDynamicComponent(graphics, widget, 10, leftClickColorWithAlpha);
+                                    highlightDynamicComponent(graphics, widget, 10);
                                 }
                                 if (currentRegionId == teleport.getRegionId()) {
                                     currentTeleportCase = 1;
@@ -1078,7 +1089,7 @@ public class FarmingTeleportOverlay extends Overlay {
                                     }
                                 } else {
                                     Widget widget = client.getWidget(teleport.getInterfaceGroupId(), teleport.getInterfaceChildId());
-                                    highlightDynamicComponent(graphics, widget, 1, leftClickColorWithAlpha);
+                                    highlightDynamicComponent(graphics, widget, 1);
                                     if (currentRegionId == teleport.getRegionId()) {
                                         currentTeleportCase = 1;
                                         isAtDestination = true;

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -405,7 +405,10 @@ public class FarmingTeleportOverlay extends Overlay {
     public void highlightCompost(Graphics2D graphics)
     {
         if (isItemInInventory(selectedCompostID())) {
+            highlightHerbPatches(graphics);
+            highlightFlowerPatches(graphics);
             highlightTreePatches(graphics);
+            highlightFruitTreePatches(graphics);
             itemHighlight(graphics, selectedCompostID());
         } else {
             withdrawCompost(graphics);
@@ -497,8 +500,7 @@ public class FarmingTeleportOverlay extends Overlay {
         }
         return -1;
     }
-    private int currentHerbCase = 1;
-    public Boolean herbPatchDone = false;
+
     private boolean isItemInInventory(int itemId) {
         ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
 
@@ -539,6 +541,8 @@ public class FarmingTeleportOverlay extends Overlay {
             }
         }
     }
+
+    public Boolean herbPatchDone = false;
 
     public void herbSteps(Graphics2D graphics, Location.Teleport teleport) {
         int currentRegionId = client.getLocalPlayer().getWorldLocation().getRegionID();
@@ -595,7 +599,6 @@ public class FarmingTeleportOverlay extends Overlay {
                     highlightCompost(graphics);
 
                     if (patchIsComposted()) {
-                        currentHerbCase = 1;
                         herbPatchDone = true;
                     }
                     break;
@@ -642,7 +645,6 @@ public class FarmingTeleportOverlay extends Overlay {
                     highlightCompost(graphics);
 
                     if (patchIsComposted()) {
-                        currentHerbCase = 1;
                         flowerPatchDone = true;
                     }
                     break;
@@ -708,7 +710,6 @@ public class FarmingTeleportOverlay extends Overlay {
                         highlightTreeFarmers(graphics);
 
                         if (patchIsProtected()) {
-                            currentHerbCase = 1;
                             treePatchDone = true;
                         }
                     } else {
@@ -717,7 +718,6 @@ public class FarmingTeleportOverlay extends Overlay {
                         highlightCompost(graphics);
 
                         if (patchIsComposted()) {
-                            currentHerbCase = 1;
                             treePatchDone = true;
                         }
                     }
@@ -784,7 +784,6 @@ public class FarmingTeleportOverlay extends Overlay {
                         highlightFruitTreeFarmers(graphics);
 
                         if (patchIsProtected()) {
-                            currentHerbCase = 1;
                             fruitTreePatchDone = true;
                         }
                     } else {
@@ -793,7 +792,6 @@ public class FarmingTeleportOverlay extends Overlay {
                         highlightCompost(graphics);
 
                         if (patchIsComposted()) {
-                            currentHerbCase = 1;
                             fruitTreePatchDone = true;
                         }
                     }

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -260,7 +260,7 @@ public class FarmingTeleportOverlay extends Overlay {
                 if (client != null) {
                     List<GameObject> gameObjects = findGameObjectsByID(objectId);
                     for (GameObject gameObject : gameObjects) {
-                        drawGameObjectClickbox(graphics, gameObject, highlightUseItemWithAlpha);
+                        drawGameObjectClickbox(graphics, gameObject, leftClickColorWithAlpha);
                     }
                 }
                 return null;
@@ -292,7 +292,7 @@ public class FarmingTeleportOverlay extends Overlay {
         return foundDecorativeObjects;
     }
 
-    public Overlay decorativeObjectOverlay(int objectId, Color color) {
+    public Overlay decorativeObjectOverlay(int objectId) {
         return new Overlay() {
             @Override
             public Dimension render(Graphics2D graphics) {
@@ -300,7 +300,7 @@ public class FarmingTeleportOverlay extends Overlay {
                 if (client != null) {
                     List<DecorativeObject> decorativeObjects = findDecorativeObjectsByID(objectId);
                     for (DecorativeObject decorativeObject : decorativeObjects) {
-                        drawDecorativeObjectClickbox(graphics, decorativeObject, color);
+                        drawDecorativeObjectClickbox(graphics, decorativeObject, leftClickColorWithAlpha);
                     }
                 }
                 return null;
@@ -1042,7 +1042,7 @@ public class FarmingTeleportOverlay extends Overlay {
 
                                 if (!isInterfaceOpen(teleport.getInterfaceGroupId(), teleport.getInterfaceChildId())) {
                                     for (int id : xericsTalismanIds) {
-                                        Overlay decorativeObjectHighlight = decorativeObjectOverlay(id, leftClickColorWithAlpha);
+                                        Overlay decorativeObjectHighlight = decorativeObjectOverlay(id);
                                         decorativeObjectHighlight.render(graphics);
                                     }
                                 } else {

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -160,13 +160,16 @@ public class FarmingTeleportOverlay extends Overlay {
         }
         return -1; // Return -1 if the specified text is not found
     }
+
     public int getChildIndexST(String searchText) {
         Widget parentWidget = client.getWidget(187, 3);
+
         if (parentWidget == null) {
             return -1;
         }
 
         Widget[] children = parentWidget.getChildren();
+
         if (children == null) {
             return -1;
         }
@@ -184,6 +187,7 @@ public class FarmingTeleportOverlay extends Overlay {
                 }
             }
         }
+
         return -1; // Return -1 if the specified text is not found
     }
 
@@ -980,17 +984,22 @@ public class FarmingTeleportOverlay extends Overlay {
                         }
                         break;
                     case SPIRIT_TREE:
-                        if (!isInterfaceOpen(17, 0)) {
+                        if (!isInterfaceOpen(187, 3)) {
                             List<Integer> spiritTreeIds = Arrays.asList(1293, 1294, 1295, 8355, 29227, 29229, 37329, 40778);
 
                             for (Integer objectId : spiritTreeIds) {
                                 gameObjectOverlay(objectId, leftClickColorWithAlpha).render(graphics);
                             }
                         } else {
-                            // TODO: The location doesn't always align with the Teleport option, meaning it won't be highlighted, such as using the Camelot teleport for Catherby
-                            int index = getChildIndexPN(location.getName());
                             Widget widget = client.getWidget(187, 3);
-                            highlightDynamicComponent(graphics, widget, index);
+
+                            if (Objects.equals(location.getName(), "Gnome Stronghold")) {
+                                highlightDynamicComponent(graphics, widget, getChildIndexST("Gnome Stronghold"));
+                            }
+
+                            if (Objects.equals(location.getName(), "Tree Gnome Village")) {
+                                highlightDynamicComponent(graphics, widget, getChildIndexST("Tree Gnome Village"));
+                            }
                         }
 
                         if (currentRegionId == teleport.getRegionId()) {

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -405,10 +405,18 @@ public class FarmingTeleportOverlay extends Overlay {
     public void highlightCompost(Graphics2D graphics)
     {
         if (isItemInInventory(selectedCompostID())) {
-            highlightHerbPatches(graphics);
-            highlightFlowerPatches(graphics);
-            highlightTreePatches(graphics);
-            highlightFruitTreePatches(graphics);
+            if (herbRun) {
+                highlightHerbPatches(graphics);
+            }
+
+            if (treeRun) {
+                highlightTreePatches(graphics);
+            }
+
+            if (fruitTreeRun) {
+                highlightFruitTreePatches(graphics);
+            }
+
             itemHighlight(graphics, selectedCompostID());
         } else {
             withdrawCompost(graphics);
@@ -609,7 +617,6 @@ public class FarmingTeleportOverlay extends Overlay {
         }
     }
 
-    //private int currentFlowerCase = 1;
     public static boolean flowerPatchDone = false;
 
     public void flowerSteps(Graphics2D graphics) {

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -22,7 +22,6 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.util.*;
 import java.util.List;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 
@@ -89,8 +88,11 @@ public class FarmingTeleportOverlay extends Overlay {
     }
 
     public boolean patchIsProtected() {
+        String standardResponse = "You pay the gardener ([0-9A-Za-z\\ ]+) to protect the patch\\.";
+        String faladorEliteResponse = "The gardener protects your tree for you, free of charge, as a token of gratitude for completing the ([A-Za-z\\ ]+)\\.";
+
         return Pattern
-            .compile("You pay the gardener ([0-9A-Za-z\\ ]+) to protect the patch\\.")
+            .compile(standardResponse + "|" + faladorEliteResponse)
             .matcher(plugin.getLastMessage())
             .matches();
     }

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -985,33 +985,29 @@ public class FarmingTeleportOverlay extends Overlay {
                         }
                         break;
                     case SPIRIT_TREE:
-                        switch (currentTeleportCase) {
-                            case 1:
-                                gettingToHouse(graphics);
-                                break;
-                            case 2:
-                                if (!isInterfaceOpen(17, 0)) {
-                                    List<Integer> spiritTreeIds = Arrays.asList(1293, 1294, 1295);
+                        if (!isInterfaceOpen(17, 0)) {
+                            List<Integer> spiritTreeIds = Arrays.asList(1293, 1294, 1295);
 
-                                    for (Integer objectId : spiritTreeIds) {
-                                        gameObjectOverlay(objectId, leftClickColorWithAlpha).render(graphics);
-                                    }
-                                } else {
-                                    // TODO: The location doesn't always align with the Teleport option, meaning it won't be highlighted, such as using the Camelot teleport for Catherby
-                                    int index = getChildIndexPN(location.getName());
-                                    Widget widget = client.getWidget(187, 3);
-                                    highlightDynamicComponent(graphics, widget, index, leftClickColorWithAlpha);
-                                }
-                                if (currentRegionId == teleport.getRegionId()) {
-                                    currentTeleportCase = 1;
-                                    isAtDestination = true;
-                                    startSubCases = true;
-                                    if (location.getFarmLimps()) {
-                                        farmLimps = true;
-                                    }
-                                }
-                                break;
+                            for (Integer objectId : spiritTreeIds) {
+                                gameObjectOverlay(objectId, leftClickColorWithAlpha).render(graphics);
+                            }
+                        } else {
+                            // TODO: The location doesn't always align with the Teleport option, meaning it won't be highlighted, such as using the Camelot teleport for Catherby
+                            int index = getChildIndexPN(location.getName());
+                            Widget widget = client.getWidget(187, 3);
+                            highlightDynamicComponent(graphics, widget, index, leftClickColorWithAlpha);
                         }
+
+                        if (currentRegionId == teleport.getRegionId()) {
+                            currentTeleportCase = 1;
+                            isAtDestination = true;
+                            startSubCases = true;
+
+                            if (location.getFarmLimps()) {
+                                farmLimps = true;
+                            }
+                        }
+
                         break;
                     case JEWELLERY_BOX:
                         switch (currentTeleportCase) {

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -991,8 +991,8 @@ public class FarmingTeleportOverlay extends Overlay {
                                 break;
                             case 2:
                                 if (!isInterfaceOpen(17, 0)) {
-                                    // TODO: Need to figure out what the game object ID of the Spirit Tree is
-                                    List<Integer> spiritTreeIds = getGameObjectIdsByName("Spirit tree");
+                                    List<Integer> spiritTreeIds = Arrays.asList(1293, 1294, 1295);
+
                                     for (Integer objectId : spiritTreeIds) {
                                         gameObjectOverlay(objectId, leftClickColorWithAlpha).render(graphics);
                                     }

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -692,6 +692,8 @@ public class FarmingTeleportOverlay extends Overlay {
     }
 
     public Boolean fruitTreePatchDone = false;
+    public Boolean fruitTreePatchComposted = false;
+    public Boolean fruitTreePatchProtected = false;
 
     public void fruitTreeSteps(Graphics2D graphics, Location.Teleport teleport) {
         int currentRegionId = client.getLocalPlayer().getWorldLocation().getRegionID();
@@ -735,12 +737,12 @@ public class FarmingTeleportOverlay extends Overlay {
                 case REMOVE:
                     plugin.addTextToInfoBox("Pay to remove fruit tree, or cut it down and clear the patch.");
                     if(!isInterfaceOpen(219, 1)) {
-                        highlightNpc(graphics, "Garth", leftClickColorWithAlpha); //Brimhaven
-                        highlightNpc(graphics, "Ellena", leftClickColorWithAlpha); //Catherby
-                        highlightNpc(graphics, "Nikkie", leftClickColorWithAlpha); //Farming Guild
-                        highlightNpc(graphics, "Bolongo", leftClickColorWithAlpha); //Gnome Stronghold
-                        highlightNpc(graphics, "Liliwen", leftClickColorWithAlpha); //Lletya
-                        highlightNpc(graphics, "Gileth", leftClickColorWithAlpha); //Tree Gnome Village
+                        highlightNpc(graphics, "Garth", leftClickColorWithAlpha); // Brimhaven
+                        highlightNpc(graphics, "Ellena", leftClickColorWithAlpha); // Catherby
+                        highlightNpc(graphics, "Nikkie", leftClickColorWithAlpha); // Farming Guild
+                        highlightNpc(graphics, "Bolongo", leftClickColorWithAlpha); // Gnome Stronghold
+                        highlightNpc(graphics, "Liliwen", leftClickColorWithAlpha); // Lletya
+                        highlightNpc(graphics, "Gileth", leftClickColorWithAlpha); // Tree Gnome Village
                     }
                     else {
                         Widget widget = client.getWidget(219, 1);
@@ -751,19 +753,46 @@ public class FarmingTeleportOverlay extends Overlay {
                     plugin.addTextToInfoBox("UNKNOWN state: Try to do something with the tree patch to change its state.");
                     break;
                 case GROWING:
-                    plugin.addTextToInfoBox("Use Compost on patch.");
-                    if(isItemInInventory(selectedCompostID())) {
-                        highlightFruitTreePatches(graphics, highlightUseItemWithAlpha);
-                        itemHighlight(graphics, selectedCompostID(), highlightUseItemWithAlpha);
-                    }
-                    else {
-                        withdrawCompost(graphics);
+                    if (!fruitTreePatchComposted) {
+                        plugin.addTextToInfoBox("Use Compost on patch.");
+
+                        if (isItemInInventory(selectedCompostID())) {
+                            highlightFruitTreePatches(graphics, highlightUseItemWithAlpha);
+                            itemHighlight(graphics, selectedCompostID(), highlightUseItemWithAlpha);
+                        } else {
+                            withdrawCompost(graphics);
+                        }
+
+                        if (isItComposted(plugin.getLastMessage())) {
+                            fruitTreePatchComposted = true;
+                        } else {
+                            // If the patch is yet to be composted, only show the compost step at this time, until it has been composted
+                            break;
+                        }
                     }
 
-                    if (isItComposted(plugin.getLastMessage())) {
+                    if (config.payForProtection() && !fruitTreePatchProtected) {
+                        plugin.addTextToInfoBox("Pay to protect the patch.");
+
+                        if (! isInterfaceOpen(219, 1)) {
+                            highlightNpc(graphics, "Garth", leftClickColorWithAlpha); // Brimhaven
+                            highlightNpc(graphics, "Ellena", leftClickColorWithAlpha); // Catherby
+                            highlightNpc(graphics, "Nikkie", leftClickColorWithAlpha); // Farming Guild
+                            highlightNpc(graphics, "Bolongo", leftClickColorWithAlpha); // Gnome Stronghold
+                            highlightNpc(graphics, "Liliwen", leftClickColorWithAlpha); // Lletya
+                            highlightNpc(graphics, "Gileth", leftClickColorWithAlpha); // Tree Gnome Village
+                        } else {
+                            Widget widget = client.getWidget(219, 1);
+                            highlightDynamicComponent(graphics, widget, 1, leftClickColorWithAlpha);
+                            fruitTreePatchProtected = true;
+                        }
+                    }
+
+                    if (fruitTreePatchComposted && (!config.payForProtection() || (config.payForProtection() && fruitTreePatchProtected))) {
                         currentHerbCase = 1;
                         fruitTreePatchDone = true;
                     }
+
                     break;
             }
         }
@@ -1129,6 +1158,8 @@ public class FarmingTeleportOverlay extends Overlay {
                     herbRunIndex++;
                     patchComposted = false;
                     fruitTreePatchDone = false;
+                    fruitTreePatchComposted = false;
+                    fruitTreePatchProtected = false;
                 }
             }
         }

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -202,7 +202,7 @@ public class FarmingTeleportOverlay extends Overlay {
         }
     }
 
-    public void itemHighlight(Graphics2D graphics, int itemID) {
+    public void itemHighlight(Graphics2D graphics, int itemID, Color color) {
         ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
 
         if (inventory != null) {
@@ -215,7 +215,7 @@ public class FarmingTeleportOverlay extends Overlay {
                 if (item.getId() == itemID) {
                     Widget itemWidget = inventoryWidget.getChild(i);
                     Rectangle bounds = itemWidget.getBounds();
-                    graphics.setColor(highlightUseItemWithAlpha);
+                    graphics.setColor(color);
                     graphics.draw(bounds);
                     graphics.fill(bounds);
                 }
@@ -252,7 +252,7 @@ public class FarmingTeleportOverlay extends Overlay {
         }
     }
 
-    public Overlay gameObjectOverlay(int objectId) {
+    public Overlay gameObjectOverlay(int objectId, Color color) {
         return new Overlay() {
             @Override
             public Dimension render(Graphics2D graphics) {
@@ -260,7 +260,7 @@ public class FarmingTeleportOverlay extends Overlay {
                 if (client != null) {
                     List<GameObject> gameObjects = findGameObjectsByID(objectId);
                     for (GameObject gameObject : gameObjects) {
-                        drawGameObjectClickbox(graphics, gameObject, leftClickColorWithAlpha);
+                        drawGameObjectClickbox(graphics, gameObject, color);
                     }
                 }
                 return null;
@@ -330,7 +330,7 @@ public class FarmingTeleportOverlay extends Overlay {
             // Check if the option text matches the desired option
             if (optionText.equalsIgnoreCase(option)) {
                 // Modify the menu entry to include a highlight
-                String highlightedText = ColorUtil.prependColorTag(">>> " + optionText, leftClickColorWithAlpha);
+                String highlightedText = ColorUtil.prependColorTag(">>> " + optionText, rightClickColorWithAlpha);
                 entry.setOption(highlightedText);
                 client.setMenuEntries(menuEntries);
                 break;
@@ -374,31 +374,31 @@ public class FarmingTeleportOverlay extends Overlay {
         }
     }
 
-    public void highlightHerbPatches(Graphics2D graphics)
+    public void highlightHerbPatches(Graphics2D graphics, Color color)
     {
         for (Integer patchId : farmingHelperOverlay.getHerbPatchIds()) {
-            gameObjectOverlay(patchId).render(graphics);
+            gameObjectOverlay(patchId, color).render(graphics);
         }
     }
 
-    public void highlightFlowerPatches(Graphics2D graphics)
+    public void highlightFlowerPatches(Graphics2D graphics, Color color)
     {
         for (Integer patchId : farmingHelperOverlay.getFlowerPatchIds()) {
-            gameObjectOverlay(patchId).render(graphics);
+            gameObjectOverlay(patchId, color).render(graphics);
         }
     }
 
-    public void highlightTreePatches(Graphics2D graphics)
+    public void highlightTreePatches(Graphics2D graphics, Color color)
     {
         for (Integer patchId : farmingHelperOverlay.getTreePatchIds()) {
-            gameObjectOverlay(patchId).render(graphics);
+            gameObjectOverlay(patchId, color).render(graphics);
         }
     }
 
-    public void highlightFruitTreePatches(Graphics2D graphics)
+    public void highlightFruitTreePatches(Graphics2D graphics, Color color)
     {
         for (Integer patchId : farmingHelperOverlay.getFruitTreePatchIds()) {
-            gameObjectOverlay(patchId).render(graphics);
+            gameObjectOverlay(patchId, color).render(graphics);
         }
     }
 
@@ -406,18 +406,18 @@ public class FarmingTeleportOverlay extends Overlay {
     {
         if (isItemInInventory(selectedCompostID())) {
             if (herbRun) {
-                highlightHerbPatches(graphics);
+                highlightHerbPatches(graphics, highlightUseItemWithAlpha);
             }
 
             if (treeRun) {
-                highlightTreePatches(graphics);
+                highlightTreePatches(graphics, highlightUseItemWithAlpha);
             }
 
             if (fruitTreeRun) {
-                highlightFruitTreePatches(graphics);
+                highlightFruitTreePatches(graphics, highlightUseItemWithAlpha);
             }
 
-            itemHighlight(graphics, selectedCompostID());
+            itemHighlight(graphics, selectedCompostID(), highlightUseItemWithAlpha);
         } else {
             withdrawCompost(graphics);
         }
@@ -460,37 +460,32 @@ public class FarmingTeleportOverlay extends Overlay {
     }
 
     public void highlightHerbSeeds(Graphics2D graphics) {
-        List<Integer> herbSeedIds = farmingHelperOverlay.getHerbSeedIds();
-        for (Integer seedId : herbSeedIds) {
-            itemHighlight(graphics, seedId);
+        for (Integer seedId : farmingHelperOverlay.getHerbSeedIds()) {
+            itemHighlight(graphics, seedId, highlightUseItemWithAlpha);
         }
     }
 
     public void highlightTreeSapling(Graphics2D graphics) {
-        List<Integer> treeSaplingIds = farmingHelperOverlay.getTreeSaplingIds();
-        for (Integer seedId : treeSaplingIds) {
-            itemHighlight(graphics, seedId);
+        for (Integer seedId : farmingHelperOverlay.getTreeSaplingIds()) {
+            itemHighlight(graphics, seedId, highlightUseItemWithAlpha);
         }
     }
 
     public void highlightFruitTreeSapling(Graphics2D graphics) {
-        List<Integer> fruitTreeSaplingIds = farmingHelperOverlay.getFruitTreeSaplingIds();
-        for (Integer seedId : fruitTreeSaplingIds) {
-            itemHighlight(graphics, seedId);
+        for (Integer seedId : farmingHelperOverlay.getFruitTreeSaplingIds()) {
+            itemHighlight(graphics, seedId, highlightUseItemWithAlpha);
         }
     }
 
     public void highlightTeleportCrystal(Graphics2D graphics) {
-        List<Integer> teleportCrystalIds = farmingHelperOverlay.getTeleportCrystalIdsIds();
-        for (Integer seedId : teleportCrystalIds) {
-            itemHighlight(graphics, seedId);
+        for (Integer seedId : farmingHelperOverlay.getTeleportCrystalIdsIds()) {
+            itemHighlight(graphics, seedId, leftClickColorWithAlpha);
         }
     }
 
     public void highlightSkillsNecklace(Graphics2D graphics) {
-        List<Integer> skillsNecklaceIds = farmingHelperOverlay.getSkillsNecklaceIdsIds();
-        for (Integer seedId : skillsNecklaceIds) {
-            itemHighlight(graphics, seedId);
+        for (Integer seedId : farmingHelperOverlay.getSkillsNecklaceIdsIds()) {
+            itemHighlight(graphics, seedId, leftClickColorWithAlpha);
         }
     }
 
@@ -575,31 +570,31 @@ public class FarmingTeleportOverlay extends Overlay {
         if (!areaCheck.isPlayerWithinArea(teleport.getPoint(), 15))
         {
             //should be replaced with a pathing system, pointing arrow or something else eventually
-            highlightHerbPatches(graphics);
+            highlightHerbPatches(graphics, leftClickColorWithAlpha);
         }
         else {
             switch (plantState) {
                 case HARVESTABLE:
                     plugin.addTextToInfoBox("Harvest Herbs.");
-                    highlightHerbPatches(graphics);
+                    highlightHerbPatches(graphics, leftClickColorWithAlpha);
                     break;
                 case PLANT:
                     plugin.addTextToInfoBox("Use Herb seed on patch.");
-                    highlightHerbPatches(graphics);
+                    highlightHerbPatches(graphics, highlightUseItemWithAlpha);
                     highlightHerbSeeds(graphics);
                     break;
                 case DEAD:
                     plugin.addTextToInfoBox("Clear the dead herb patch.");
-                    highlightHerbPatches(graphics);
+                    highlightHerbPatches(graphics, leftClickColorWithAlpha);
                     break;
                 case DISEASED:
                     plugin.addTextToInfoBox("Use Plant cure on herb patch. Buy at GE or in farming guild/catherby, and store at Tool Leprechaun for easy access.");
-                    highlightHerbPatches(graphics);
-                    itemHighlight(graphics, ItemID.PLANT_CURE);
+                    highlightHerbPatches(graphics, leftClickColorWithAlpha);
+                    itemHighlight(graphics, ItemID.PLANT_CURE, highlightUseItemWithAlpha);
                     break;
                 case WEEDS:
                     plugin.addTextToInfoBox("Rake the herb patch.");
-                    highlightHerbPatches(graphics);
+                    highlightHerbPatches(graphics, leftClickColorWithAlpha);
                     break;
                 case GROWING:
                     plugin.addTextToInfoBox("Use Compost on patch.");
@@ -631,20 +626,20 @@ public class FarmingTeleportOverlay extends Overlay {
             switch (plantState) {
                 case HARVESTABLE:
                     plugin.addTextToInfoBox("Harvest Limwurt root.");
-                    highlightFlowerPatches(graphics);
+                    highlightFlowerPatches(graphics, leftClickColorWithAlpha);
                     break;
                 case WEEDS:
                     plugin.addTextToInfoBox("Rake the flower patch.");
-                    highlightFlowerPatches(graphics);
+                    highlightFlowerPatches(graphics, leftClickColorWithAlpha);
                     break;
                 case DEAD:
                     plugin.addTextToInfoBox("Clear the dead flower patch.");
-                    highlightFlowerPatches(graphics);
+                    highlightFlowerPatches(graphics, leftClickColorWithAlpha);
                     break;
                 case PLANT:
                     plugin.addTextToInfoBox("Use Limwurt seed on the patch.");
-                    highlightFlowerPatches(graphics);
-                    itemHighlight(graphics, ItemID.LIMPWURT_SEED);
+                    highlightFlowerPatches(graphics, highlightUseItemWithAlpha);
+                    itemHighlight(graphics, ItemID.LIMPWURT_SEED, highlightUseItemWithAlpha);
                     break;
                 case GROWING:
                     plugin.addTextToInfoBox("Use Compost on patch.");
@@ -676,30 +671,30 @@ public class FarmingTeleportOverlay extends Overlay {
         if (!areaCheck.isPlayerWithinArea(teleport.getPoint(), 15))
         {
             //should be replaced with a pathing system, pointing arrow or something else eventually
-            highlightTreePatches(graphics);
+            highlightTreePatches(graphics, leftClickColorWithAlpha);
         }
         else {
             switch (plantState) {
                 case HEALTHY:
                     plugin.addTextToInfoBox("Check tree health.");
-                    highlightTreePatches(graphics);
+                    highlightTreePatches(graphics, leftClickColorWithAlpha);
                     break;
                 case WEEDS:
                     plugin.addTextToInfoBox("Rake the tree patch.");
-                    highlightTreePatches(graphics);
+                    highlightTreePatches(graphics, leftClickColorWithAlpha);
                     break;
                 case DEAD:
                     plugin.addTextToInfoBox("Clear the dead tree patch.");
-                    highlightTreePatches(graphics);
+                    highlightTreePatches(graphics, leftClickColorWithAlpha);
                     break;
                 case PLANT:
                     plugin.addTextToInfoBox("Use Sapling on the patch.");
-                    highlightTreePatches(graphics);
+                    highlightTreePatches(graphics, highlightUseItemWithAlpha);
                     highlightTreeSapling(graphics);
                     break;
                 case DISEASED:
                     plugin.addTextToInfoBox("Prune the tree patch patch.");
-                    highlightTreePatches(graphics);
+                    highlightTreePatches(graphics, highlightUseItemWithAlpha);
                     break;
                 case REMOVE:
                     plugin.addTextToInfoBox("Pay to remove tree, or cut it down and clear the patch.");
@@ -751,29 +746,29 @@ public class FarmingTeleportOverlay extends Overlay {
         }
         if (!areaCheck.isPlayerWithinArea(teleport.getPoint(), 15)) {
             //should be replaced with a pathing system, point arrow or something else eventually
-            highlightFruitTreePatches(graphics);
+            highlightFruitTreePatches(graphics, leftClickColorWithAlpha);
         } else {
             switch (plantState) {
                 case HEALTHY:
                     plugin.addTextToInfoBox("Check Fruit tree health.");
-                    highlightFruitTreePatches(graphics);
+                    highlightFruitTreePatches(graphics, leftClickColorWithAlpha);
                     break;
                 case WEEDS:
                     plugin.addTextToInfoBox("Rake the fruit tree patch.");
-                    highlightFruitTreePatches(graphics);
+                    highlightFruitTreePatches(graphics, leftClickColorWithAlpha);
                     break;
                 case DEAD:
                     plugin.addTextToInfoBox("Clear the dead fruit tree patch.");
-                    highlightFruitTreePatches(graphics);
+                    highlightFruitTreePatches(graphics, leftClickColorWithAlpha);
                     break;
                 case PLANT:
                     plugin.addTextToInfoBox("Use Sapling on the patch.");
-                    highlightFruitTreePatches(graphics);
+                    highlightFruitTreePatches(graphics, highlightUseItemWithAlpha);
                     highlightFruitTreeSapling(graphics);
                     break;
                 case DISEASED:
                     plugin.addTextToInfoBox("Prune the fruit tree patch.");
-                    highlightFruitTreePatches(graphics);
+                    highlightFruitTreePatches(graphics, leftClickColorWithAlpha);
                     break;
                 case REMOVE:
                     plugin.addTextToInfoBox("Pay to remove fruit tree, or cut it down and clear the patch.");
@@ -859,19 +854,19 @@ public class FarmingTeleportOverlay extends Overlay {
                 }
             case Teleport_To_House:
                 inHouseCheck();
-                itemHighlight(graphics, ItemID.TELEPORT_TO_HOUSE);
+                itemHighlight(graphics, ItemID.TELEPORT_TO_HOUSE, leftClickColorWithAlpha);
                 break;
             case Construction_cape:
                 inHouseCheck();
-                itemHighlight(graphics, ItemID.CONSTRUCT_CAPE);
+                itemHighlight(graphics, ItemID.CONSTRUCT_CAPE, rightClickColorWithAlpha);
                 break;
             case Construction_cape_t:
                 inHouseCheck();
-                itemHighlight(graphics, ItemID.CONSTRUCT_CAPET);
+                itemHighlight(graphics, ItemID.CONSTRUCT_CAPET, rightClickColorWithAlpha);
                 break;
             case Max_cape:
                 inHouseCheck();
-                itemHighlight(graphics, ItemID.MAX_CAPE);
+                itemHighlight(graphics, ItemID.MAX_CAPE, rightClickColorWithAlpha);
                 break;
         }
     }
@@ -902,7 +897,7 @@ public class FarmingTeleportOverlay extends Overlay {
                     case ITEM:
                         if (teleport.getInterfaceGroupId() != 0) {
                             if (!isInterfaceOpen(teleport.getInterfaceGroupId(), teleport.getInterfaceChildId())) {
-                                itemHighlight(graphics, teleport.getId());
+                                itemHighlight(graphics, teleport.getId(), rightClickColorWithAlpha);
                                 if (!teleport.getRightClickOption().equals("null")) {
                                     highlightRightClickOption(graphics, teleport.getRightClickOption());
                                 }
@@ -920,7 +915,7 @@ public class FarmingTeleportOverlay extends Overlay {
                             }
                         } else {
                             if (!teleport.getRightClickOption().equals("null")) {
-                                itemHighlight(graphics, teleport.getId());
+                                itemHighlight(graphics, teleport.getId(), rightClickColorWithAlpha);
                                 highlightRightClickOption(graphics, teleport.getRightClickOption());
                             } else {
                                 if(teleport.getId() == ItemID.TELEPORT_CRYSTAL_1) {
@@ -943,7 +938,7 @@ public class FarmingTeleportOverlay extends Overlay {
                                 }
 
                                 else {
-                                    itemHighlight(graphics, teleport.getId());
+                                    itemHighlight(graphics, teleport.getId(), leftClickColorWithAlpha);
                                 }
                             }
                             if (currentRegionId == teleport.getRegionId()) {
@@ -965,7 +960,7 @@ public class FarmingTeleportOverlay extends Overlay {
                                 if (!isInterfaceOpen(17, 0)) {
                                     List<Integer> portalNexusIds = getGameObjectIdsByName("Portal Nexus");
                                     for (Integer objectId : portalNexusIds) {
-                                        gameObjectOverlay(objectId).render(graphics);
+                                        gameObjectOverlay(objectId, leftClickColorWithAlpha).render(graphics);
                                     }
                                 } else {
                                     // TODO: The location doesn't always align with the Teleport option, meaning it won't be highlighted, such as using the Camelot teleport for Catherby
@@ -989,7 +984,7 @@ public class FarmingTeleportOverlay extends Overlay {
                             List<Integer> spiritTreeIds = Arrays.asList(1293, 1294, 1295, 8355, 29227, 29229, 37329, 40778);
 
                             for (Integer objectId : spiritTreeIds) {
-                                gameObjectOverlay(objectId).render(graphics);
+                                gameObjectOverlay(objectId, leftClickColorWithAlpha).render(graphics);
                             }
                         } else {
                             // TODO: The location doesn't always align with the Teleport option, meaning it won't be highlighted, such as using the Camelot teleport for Catherby
@@ -1019,9 +1014,9 @@ public class FarmingTeleportOverlay extends Overlay {
 
                                 if (!isInterfaceOpen(590, 0)) {
                                     for (int id : jewelleryBoxIds) {
-                                        gameObjectOverlay(id).render(graphics);
+                                        gameObjectOverlay(id, leftClickColorWithAlpha).render(graphics);
                                     }
-                                    gameObjectOverlay(teleport.getId()).render(graphics);
+                                    gameObjectOverlay(teleport.getId(), leftClickColorWithAlpha).render(graphics);
                                 } else {
                                     Widget widget = client.getWidget(590, 5);
                                     highlightDynamicComponent(graphics, widget, 10);

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -4,16 +4,13 @@ import java.awt.*;
 import javax.inject.Inject;
 
 import net.runelite.api.*;
-import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
-import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.api.ItemID;
 import net.runelite.client.util.ColorUtil;
@@ -90,6 +87,13 @@ public class FarmingTeleportOverlay extends Overlay {
         Matcher matcherCompost = patternCompost.matcher(plugin.getLastMessage());
 
         return matcherCompost.matches();
+    }
+
+    public boolean patchIsProtected() {
+        return Pattern
+            .compile("You pay the gardener ([0-9A-Za-z\\ ]+) to protect the patch\\.")
+            .matcher(plugin.getLastMessage())
+            .matches();
     }
 
     @Inject
@@ -677,6 +681,9 @@ public class FarmingTeleportOverlay extends Overlay {
                         } else {
                             Widget widget = client.getWidget(219, 1);
                             highlightDynamicComponent(graphics, widget, 1, leftClickColorWithAlpha);
+                        }
+
+                        if (patchIsProtected()) {
                             treePatchProtected = true;
                         }
                     }
@@ -784,6 +791,9 @@ public class FarmingTeleportOverlay extends Overlay {
                         } else {
                             Widget widget = client.getWidget(219, 1);
                             highlightDynamicComponent(graphics, widget, 1, leftClickColorWithAlpha);
+                        }
+
+                        if (patchIsProtected()) {
                             fruitTreePatchProtected = true;
                         }
                     }

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -410,7 +410,14 @@ public class FarmingTeleportOverlay extends Overlay {
     {
         if (isItemInInventory(selectedCompostID())) {
             if (herbRun) {
-                highlightHerbPatches(graphics, highlightUseItemWithAlpha);
+                if (subCase == 1) {
+                    highlightHerbPatches(graphics, highlightUseItemWithAlpha);
+
+                }
+                else if(subCase == 2) {
+                    highlightFlowerPatches(graphics, highlightUseItemWithAlpha);
+                }
+
             }
 
             if (treeRun) {
@@ -984,34 +991,49 @@ public class FarmingTeleportOverlay extends Overlay {
                         }
                         break;
                     case SPIRIT_TREE:
-                        if (!isInterfaceOpen(187, 3)) {
-                            List<Integer> spiritTreeIds = Arrays.asList(1293, 1294, 1295, 8355, 29227, 29229, 37329, 40778);
+                        switch (currentTeleportCase) {
+                            case 1:
+                                gettingToHouse(graphics);
+                                break;
+                            case 2:
+                                if (!isInterfaceOpen(187, 3)) {
+                                    //Might be more
+                                    List<Integer> spiritTreeIds = Arrays.asList(1293, 1294, 1295, 8355, 29227, 29229, 37329, 40778);
+                                    for (Integer objectId : spiritTreeIds) {
+                                        gameObjectOverlay(objectId, leftClickColorWithAlpha).render(graphics);
+                                    }
+                                } else {
+                                    Widget widget = client.getWidget(187, 3);
+                                    int index = getChildIndexST(location.getName());
+                                    highlightDynamicComponent(graphics, widget, index);
+                                    if (Objects.equals(
+                                        location.getName(),
+                                        "Falador"
+                                    ))
+                                    {
+                                        int altIndex = getChildIndexST("Port Sarim");
+                                        highlightDynamicComponent(graphics, widget, altIndex);
+                                    }
+                                    if (Objects.equals(
+                                        location.getName(),
+                                        "Kourend"
+                                    ))
+                                    {
+                                        int altIndex = getChildIndexST("Hosidius");
+                                        highlightDynamicComponent(graphics, widget, altIndex);
+                                    }
 
-                            for (Integer objectId : spiritTreeIds) {
-                                gameObjectOverlay(objectId, leftClickColorWithAlpha).render(graphics);
-                            }
-                        } else {
-                            Widget widget = client.getWidget(187, 3);
-
-                            if (Objects.equals(location.getName(), "Gnome Stronghold")) {
-                                highlightDynamicComponent(graphics, widget, getChildIndexST("Gnome Stronghold"));
-                            }
-
-                            if (Objects.equals(location.getName(), "Tree Gnome Village")) {
-                                highlightDynamicComponent(graphics, widget, getChildIndexST("Tree Gnome Village"));
-                            }
+                                }
+                                if (currentRegionId == teleport.getRegionId()) {
+                                    currentTeleportCase = 1;
+                                    isAtDestination = true;
+                                    startSubCases = true;
+                                    if (location.getFarmLimps()) {
+                                        farmLimps = true;
+                                    }
+                                }
+                                break;
                         }
-
-                        if (currentRegionId == teleport.getRegionId()) {
-                            currentTeleportCase = 1;
-                            isAtDestination = true;
-                            startSubCases = true;
-
-                            if (location.getFarmLimps()) {
-                                farmLimps = true;
-                            }
-                        }
-
                         break;
                     case JEWELLERY_BOX:
                         switch (currentTeleportCase) {

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -78,15 +78,14 @@ public class FarmingTeleportOverlay extends Overlay {
 
 
 
-    public boolean isItComposted(String message) {
+    public boolean patchIsComposted() {
         String regexCompost1 = "You treat the (herb patch|flower patch|tree patch|fruit tree patch) with (compost|supercompost|ultracompost)\\.";
         String regexCompost2 = "This (herb patch|flower patch|tree patch|fruit tree patch) has already been treated with (compost|supercompost|ultracompost)\\.";
-        String combinedRegex = regexCompost1 + "|" + regexCompost2;
 
-        Pattern patternCompost = Pattern.compile(combinedRegex);
-        Matcher matcherCompost = patternCompost.matcher(plugin.getLastMessage());
-
-        return matcherCompost.matches();
+        return Pattern
+            .compile(regexCompost1 + "|" + regexCompost2)
+            .matcher(plugin.getLastMessage())
+            .matches();
     }
 
     public boolean patchIsProtected() {
@@ -555,14 +554,10 @@ public class FarmingTeleportOverlay extends Overlay {
                     break;
                 case GROWING:
                     plugin.addTextToInfoBox("Use Compost on patch.");
-                    if(isItemInInventory(selectedCompostID())) {
-                        highlightHerbPatches(graphics, highlightUseItemWithAlpha);
-                        itemHighlight(graphics, selectedCompostID(), highlightUseItemWithAlpha);
-                    }
-                    else {
-                        withdrawCompost(graphics);
-                    }
-                    if (isItComposted(plugin.getLastMessage())) {
+
+                    highlightCompost(graphics);
+
+                    if (patchIsComposted()) {
                         currentHerbCase = 1;
                         herbPatchDone = true;
                     }
@@ -606,15 +601,10 @@ public class FarmingTeleportOverlay extends Overlay {
                     break;
                 case GROWING:
                     plugin.addTextToInfoBox("Use Compost on patch.");
-                    if(isItemInInventory(selectedCompostID())) {
-                        highlightFlowerPatches(graphics, highlightUseItemWithAlpha);
-                        itemHighlight(graphics, selectedCompostID(), highlightUseItemWithAlpha);
-                    }
-                    else {
-                        withdrawCompost(graphics);
-                    }
 
-                    if (isItComposted(plugin.getLastMessage())) {
+                    highlightCompost(graphics);
+
+                    if (patchIsComposted()) {
                         currentHerbCase = 1;
                         flowerPatchDone = true;
                     }
@@ -628,7 +618,6 @@ public class FarmingTeleportOverlay extends Overlay {
     public Boolean treePatchDone = false;
     public Boolean treePatchComposted = false;
     public Boolean treePatchProtected = false;
-    public Boolean patchComposted = false;
 
     public void treeSteps(Graphics2D graphics, Location.Teleport teleport) {
         int currentRegionId = client.getLocalPlayer().getWorldLocation().getRegionID();
@@ -1155,7 +1144,6 @@ public class FarmingTeleportOverlay extends Overlay {
                     if (herbPatchDone) {
                         subCase = 2;
                         herbPatchDone = false;
-                        patchComposted = false;
                     }
                 } else if (subCase == 2) {
                     if (config.generalLimpwurt()) {
@@ -1167,7 +1155,6 @@ public class FarmingTeleportOverlay extends Overlay {
                             herbRunIndex++;
                             farmLimps = false;
                             flowerPatchDone = false;
-                            patchComposted = false;
 
                         }
                     } else {
@@ -1177,7 +1164,6 @@ public class FarmingTeleportOverlay extends Overlay {
                         herbRunIndex++;
                         farmLimps = false;
                         flowerPatchDone = false;
-                        patchComposted = false;
                     }
                 }
             }
@@ -1187,7 +1173,6 @@ public class FarmingTeleportOverlay extends Overlay {
                     startSubCases = false;
                     isAtDestination = false;
                     herbRunIndex++;
-                    patchComposted = false;
                     treePatchDone = false;
                     treePatchComposted = false;
                     treePatchProtected = false;
@@ -1199,7 +1184,6 @@ public class FarmingTeleportOverlay extends Overlay {
                     startSubCases = false;
                     isAtDestination = false;
                     herbRunIndex++;
-                    patchComposted = false;
                     fruitTreePatchDone = false;
                     fruitTreePatchComposted = false;
                     fruitTreePatchProtected = false;

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -134,13 +134,14 @@ public class FarmingTeleportOverlay extends Overlay {
         };
     }
 
-    public int getChildIndexPN(String searchText) {
-        Widget parentWidget = client.getWidget(17, 12);
+    public int getChildIndex(String searchText, Widget parentWidget)
+    {
         if (parentWidget == null) {
             return -1;
         }
 
         Widget[] children = parentWidget.getChildren();
+
         if (children == null) {
             return -1;
         }
@@ -148,47 +149,37 @@ public class FarmingTeleportOverlay extends Overlay {
         for (int index = 0; index < children.length; index++) {
             Widget child = children[index];
             String text = child.getText();
+
             if (text != null) {
                 int colonIndex = text.indexOf(':');
+
                 if (colonIndex != -1 && colonIndex + 1 < text.length()) {
                     String textAfterColon = text.substring(colonIndex + 1).trim();
+
                     if (textAfterColon.equals(searchText)) {
                         return index;
                     }
                 }
             }
         }
+
         return -1; // Return -1 if the specified text is not found
     }
 
-    public int getChildIndexST(String searchText) {
-        Widget parentWidget = client.getWidget(187, 3);
+    public int getChildIndexPortalNexus(String searchText)
+    {
+        return getChildIndex(
+            searchText,
+            client.getWidget(17, 12)
+        );
+    }
 
-        if (parentWidget == null) {
-            return -1;
-        }
-
-        Widget[] children = parentWidget.getChildren();
-
-        if (children == null) {
-            return -1;
-        }
-
-        for (int index = 0; index < children.length; index++) {
-            Widget child = children[index];
-            String text = child.getText();
-            if (text != null) {
-                int colonIndex = text.indexOf(':');
-                if (colonIndex != -1 && colonIndex + 1 < text.length()) {
-                    String textAfterColon = text.substring(colonIndex + 1).trim();
-                    if (textAfterColon.equals(searchText)) {
-                        return index;
-                    }
-                }
-            }
-        }
-
-        return -1; // Return -1 if the specified text is not found
+    public int getChildIndexSpiritTree(String searchText)
+    {
+        return getChildIndex(
+            searchText,
+            client.getWidget(187, 3)
+        );
     }
 
     public void highlightDynamicComponent(Graphics2D graphics, Widget widget, int dynamicChildIndex) {
@@ -976,7 +967,7 @@ public class FarmingTeleportOverlay extends Overlay {
                                 } else {
                                     // TODO: The location doesn't always align with the Teleport option, meaning it won't be highlighted, such as using the Camelot teleport for Catherby
                                     Widget widget = client.getWidget(17, 13);
-                                    int index = getChildIndexPN(location.getName());
+                                    int index = getChildIndexPortalNexus(location.getName());
                                     highlightDynamicComponent(graphics, widget, index);
                                 }
                                 if (currentRegionId == teleport.getRegionId()) {
@@ -991,48 +982,38 @@ public class FarmingTeleportOverlay extends Overlay {
                         }
                         break;
                     case SPIRIT_TREE:
-                        switch (currentTeleportCase) {
-                            case 1:
-                                gettingToHouse(graphics);
-                                break;
-                            case 2:
-                                if (!isInterfaceOpen(187, 3)) {
-                                    //Might be more
-                                    List<Integer> spiritTreeIds = Arrays.asList(1293, 1294, 1295, 8355, 29227, 29229, 37329, 40778);
-                                    for (Integer objectId : spiritTreeIds) {
-                                        gameObjectOverlay(objectId, leftClickColorWithAlpha).render(graphics);
-                                    }
-                                } else {
-                                    Widget widget = client.getWidget(187, 3);
-                                    int index = getChildIndexST(location.getName());
-                                    highlightDynamicComponent(graphics, widget, index);
-                                    if (Objects.equals(
-                                        location.getName(),
-                                        "Falador"
-                                    ))
-                                    {
-                                        int altIndex = getChildIndexST("Port Sarim");
-                                        highlightDynamicComponent(graphics, widget, altIndex);
-                                    }
-                                    if (Objects.equals(
-                                        location.getName(),
-                                        "Kourend"
-                                    ))
-                                    {
-                                        int altIndex = getChildIndexST("Hosidius");
-                                        highlightDynamicComponent(graphics, widget, altIndex);
-                                    }
+                        if (!isInterfaceOpen(187, 3)) {
+                            List<Integer> spiritTreeIds = Arrays.asList(1293, 1294, 1295, 8355, 29227, 29229, 37329, 40778);
 
-                                }
-                                if (currentRegionId == teleport.getRegionId()) {
-                                    currentTeleportCase = 1;
-                                    isAtDestination = true;
-                                    startSubCases = true;
-                                    if (location.getFarmLimps()) {
-                                        farmLimps = true;
-                                    }
-                                }
-                                break;
+                            for (Integer objectId : spiritTreeIds) {
+                                gameObjectOverlay(objectId, leftClickColorWithAlpha).render(graphics);
+                            }
+                        } else {
+                            Widget widget = client.getWidget(187, 3);
+
+                            switch (location.getName()) {
+                                case "Gnome Stronghold":
+                                    highlightDynamicComponent(graphics, widget, getChildIndexSpiritTree("Gnome Stronghold"));
+
+                                case "Tree Gnome Village":
+                                    highlightDynamicComponent(graphics, widget, getChildIndexSpiritTree("Tree Gnome Village"));
+
+                                case "Falador":
+                                    highlightDynamicComponent(graphics, widget, getChildIndexSpiritTree("Port Sarim"));
+
+                                case "Kourend":
+                                    highlightDynamicComponent(graphics, widget, getChildIndexSpiritTree("Hosidius"));
+                            }
+                        }
+
+                        if (currentRegionId == teleport.getRegionId()) {
+                            currentTeleportCase = 1;
+                            isAtDestination = true;
+                            startSubCases = true;
+
+                            if (location.getFarmLimps()) {
+                                farmLimps = true;
+                            }
                         }
                         break;
                     case JEWELLERY_BOX:

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/FruitTreeRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/FruitTreeRunItemAndLocation.java
@@ -303,8 +303,7 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation
             3,
             9781,
             gnomeStrongholdFruitTreePatchPoint,
-            // TODO: Change this to no requirements? House is handy for people with a tree in their home
-            getHouseTeleportItemRequirements()
+            Collections.<ItemRequirement> emptyList()
         ));
 
         locations.add(gnomeStrongholdFruitTreeLocation);
@@ -385,8 +384,7 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation
             3,
             10033,
             treeGnomeVillageFruitTreePatchPoint,
-            // TODO: Change this to no requirements? House is handy for people with a tree in their home
-            getHouseTeleportItemRequirements()
+            Collections.<ItemRequirement> emptyList()
         ));
 
         locations.add(treeGnomeVillageFruitTreeLocation);

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/TreeRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/TreeRunItemAndLocation.java
@@ -259,8 +259,7 @@ public class TreeRunItemAndLocation extends ItemAndLocation
             3,
             9781,
             gnomeStrongholdTreePatchPoint,
-            // TODO: Change this to no requirements? House is handy for people with a tree in their home
-            getHouseTeleportItemRequirements()
+            Collections.<ItemRequirement> emptyList()
         ));
 
         locations.add(gnomeStrongholdTreeLocation);


### PR DESCRIPTION
Closes #8.

- Add an option to have a reminder to pay for protection before teleporting onwards to the next patch for trees and fruit trees.
- Store a default macOS run configuration for IntelliJ, as there are some extra options required, so will be helpful to get people up and running on the project quicker
- Fix spirit trees not being highlighted (didn't realise you'd also picked up on it in #9, in the merge conflict I've just rolled the extra ID's you found into the ones I found too, then rolled forwards on the change below)
- Fix spirit trees requiring a home teleport as the first step, instead now it just highlights all spirit trees on the map