### PR TITLE
Fix for teleport name selection if it differs to the location name

### DIFF
--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -134,7 +134,7 @@ public class FarmingTeleportOverlay extends Overlay {
         };
     }
 
-    public int getChildIndex(String searchText, Widget parentWidget)
+    public int getChildIndex(Widget parentWidget, String searchText)
     {
         if (parentWidget == null) {
             return -1;
@@ -164,22 +164,6 @@ public class FarmingTeleportOverlay extends Overlay {
         }
 
         return -1; // Return -1 if the specified text is not found
-    }
-
-    public int getChildIndexPortalNexus(String searchText)
-    {
-        return getChildIndex(
-            searchText,
-            client.getWidget(17, 12)
-        );
-    }
-
-    public int getChildIndexSpiritTree(String searchText)
-    {
-        return getChildIndex(
-            searchText,
-            client.getWidget(187, 3)
-        );
     }
 
     public void highlightDynamicComponent(Graphics2D graphics, Widget widget, int dynamicChildIndex) {
@@ -961,24 +945,29 @@ public class FarmingTeleportOverlay extends Overlay {
                             case 2:
                                 if (!isInterfaceOpen(17, 0)) {
                                     List<Integer> portalNexusIds = getGameObjectIdsByName("Portal Nexus");
+
                                     for (Integer objectId : portalNexusIds) {
                                         gameObjectOverlay(objectId, leftClickColorWithAlpha).render(graphics);
                                     }
                                 } else {
-                                    Widget widget = client.getWidget(17, 13);
+                                    Widget widget = client.getWidget(17, 12);
 
-                                    highlightDynamicComponent(graphics, widget, getChildIndexPortalNexus(
+                                    highlightDynamicComponent(graphics, widget, getChildIndex(
+                                        widget,
                                         teleport.overrideLocationName() == "" ? location.getName() : teleport.overrideLocationName()
                                     ));
                                 }
+
                                 if (currentRegionId == teleport.getRegionId()) {
                                     currentTeleportCase = 1;
                                     isAtDestination = true;
                                     startSubCases = true;
+
                                     if (location.getFarmLimps()) {
                                         farmLimps = true;
                                     }
                                 }
+
                                 break;
                         }
                         break;
@@ -994,16 +983,16 @@ public class FarmingTeleportOverlay extends Overlay {
 
                             switch (location.getName()) {
                                 case "Gnome Stronghold":
-                                    highlightDynamicComponent(graphics, widget, getChildIndexSpiritTree("Gnome Stronghold"));
+                                    highlightDynamicComponent(graphics, widget, getChildIndex(widget, "Gnome Stronghold"));
 
                                 case "Tree Gnome Village":
-                                    highlightDynamicComponent(graphics, widget, getChildIndexSpiritTree("Tree Gnome Village"));
+                                    highlightDynamicComponent(graphics, widget, getChildIndex(widget, "Tree Gnome Village"));
 
                                 case "Falador":
-                                    highlightDynamicComponent(graphics, widget, getChildIndexSpiritTree("Port Sarim"));
+                                    highlightDynamicComponent(graphics, widget, getChildIndex(widget, "Port Sarim"));
 
                                 case "Kourend":
-                                    highlightDynamicComponent(graphics, widget, getChildIndexSpiritTree("Hosidius"));
+                                    highlightDynamicComponent(graphics, widget, getChildIndex(widget, "Hosidius"));
                             }
                         }
 

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -982,17 +982,14 @@ public class FarmingTeleportOverlay extends Overlay {
                             Widget widget = client.getWidget(187, 3);
 
                             switch (location.getName()) {
-                                case "Gnome Stronghold":
-                                    highlightDynamicComponent(graphics, widget, getChildIndex(widget, "Gnome Stronghold"));
-
-                                case "Tree Gnome Village":
-                                    highlightDynamicComponent(graphics, widget, getChildIndex(widget, "Tree Gnome Village"));
-
                                 case "Falador":
                                     highlightDynamicComponent(graphics, widget, getChildIndex(widget, "Port Sarim"));
 
                                 case "Kourend":
                                     highlightDynamicComponent(graphics, widget, getChildIndex(widget, "Hosidius"));
+
+                                default:
+                                    highlightDynamicComponent(graphics, widget, getChildIndex(widget, location.getName()));
                             }
                         }
 

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -965,10 +965,11 @@ public class FarmingTeleportOverlay extends Overlay {
                                         gameObjectOverlay(objectId, leftClickColorWithAlpha).render(graphics);
                                     }
                                 } else {
-                                    // TODO: The location doesn't always align with the Teleport option, meaning it won't be highlighted, such as using the Camelot teleport for Catherby
                                     Widget widget = client.getWidget(17, 13);
-                                    int index = getChildIndexPortalNexus(location.getName());
-                                    highlightDynamicComponent(graphics, widget, index);
+
+                                    highlightDynamicComponent(graphics, widget, getChildIndexPortalNexus(
+                                        teleport.overrideLocationName() == "" ? location.getName() : teleport.overrideLocationName()
+                                    ));
                                 }
                                 if (currentRegionId == teleport.getRegionId()) {
                                     currentTeleportCase = 1;

--- a/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
+++ b/src/main/java/com/farminghelper/speaax/FarmingTeleportOverlay.java
@@ -950,10 +950,10 @@ public class FarmingTeleportOverlay extends Overlay {
                                         gameObjectOverlay(objectId, leftClickColorWithAlpha).render(graphics);
                                     }
                                 } else {
-                                    Widget widget = client.getWidget(17, 12);
+                                    Widget widget = client.getWidget(17, 13);
 
                                     highlightDynamicComponent(graphics, widget, getChildIndex(
-                                        widget,
+                                        client.getWidget(17, 12),
                                         teleport.overrideLocationName() == "" ? location.getName() : teleport.overrideLocationName()
                                     ));
                                 }

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/FruitTreeRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/FruitTreeRunItemAndLocation.java
@@ -156,7 +156,7 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation
             10547,
             brimhavenFruitTreePatchPoint,
             getHouseTeleportItemRequirements()
-        ));
+        ).overrideLocationName("Ardougne"));
 
         brimhavenFruitTreeLocation.addTeleportOption(brimhavenFruitTreeLocation.new Teleport(
             "Ardougne_teleport",
@@ -218,7 +218,7 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation
         catherbyFruitTreeLocation.addTeleportOption(catherbyFruitTreeLocation.new Teleport(
             "Portal_Nexus_Camelot",
             Location.TeleportCategory.PORTAL_NEXUS,
-            "Teleport to Camelot with Portal Nexus.",
+            "Teleport to Camelot with Portal Nexus and run to Catherby.",
             0,
             "null",
             17,
@@ -226,7 +226,7 @@ public class FruitTreeRunItemAndLocation extends ItemAndLocation
             11062,
             cathebyFruitTreePatchPoint,
             getHouseTeleportItemRequirements()
-        ));
+        ).overrideLocationName("Camelot"));
 
         locations.add(catherbyFruitTreeLocation);
     }

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/HerbRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/HerbRunItemAndLocation.java
@@ -324,7 +324,7 @@ public class HerbRunItemAndLocation extends ItemAndLocation
         catherbyLocation.addTeleportOption(catherbyLocation.new Teleport(
             "Portal_Nexus_Camelot",
             Location.TeleportCategory.PORTAL_NEXUS,
-            "Teleport to Camelot with Portal Nexus.",
+            "Teleport to Camelot with Portal Nexus and run to Catherby.",
             0,
             "null",
             17,
@@ -332,7 +332,7 @@ public class HerbRunItemAndLocation extends ItemAndLocation
             11062,
             catherbyHerbPatchPoint,
             getHouseTeleportItemRequirements()
-        ));
+        ).overrideLocationName("Camelot"));
 
         catherbyLocation.addTeleportOption(catherbyLocation.new Teleport(
             "Camelot_Teleport",

--- a/src/main/java/com/farminghelper/speaax/ItemsAndLocations/TreeRunItemAndLocation.java
+++ b/src/main/java/com/farminghelper/speaax/ItemsAndLocations/TreeRunItemAndLocation.java
@@ -348,7 +348,7 @@ public class TreeRunItemAndLocation extends ItemAndLocation
             11828,
             taverlyPatchPoint,
             getHouseTeleportItemRequirements()
-        ));
+        ).overrideLocationName("Falador"));
 
         taverleyTreeLocation.addTeleportOption(taverleyTreeLocation.new Teleport(
             "Falador_teleport",

--- a/src/main/java/com/farminghelper/speaax/Location.java
+++ b/src/main/java/com/farminghelper/speaax/Location.java
@@ -72,6 +72,7 @@ public class Location {
         private String rightClickOption;
         private List<ItemRequirement> itemRequirements;
         private WorldPoint point;
+        private String overrideLocationName;
 
         public Teleport(String enumOption, TeleportCategory category, String description, int id, String rightClickOption, int interfaceGroupId, int interfaceChildId, int regionId, WorldPoint point, List<ItemRequirement> itemRequirements) {
             this.enumOption = enumOption;
@@ -84,6 +85,7 @@ public class Location {
             this.regionId = regionId;
             this.point = point;
             this.itemRequirements = itemRequirements;
+            this.overrideLocationName = "";
         }
 
         public Map<Integer, Integer> getItemRequirements() {
@@ -106,6 +108,18 @@ public class Location {
 
         public void updateTeleportItemId(int newItemId) {
             this.id = newItemId;
+        }
+
+        public Location.Teleport overrideLocationName(String overrideLocationName)
+        {
+            this.overrideLocationName = overrideLocationName;
+
+            return this;
+        }
+
+        public String overrideLocationName()
+        {
+            return this.overrideLocationName;
         }
 
         public TeleportCategory getCategory() {


### PR DESCRIPTION
This fixes the teleport options by allowing an override to be specified if the teleport name differs to the location name.