### PR TITLE
Fix more than 1 Ultracompost not being detected.

### DIFF
--- a/src/main/java/com/easyfarming/EasyFarmingOverlay.java
+++ b/src/main/java/com/easyfarming/EasyFarmingOverlay.java
@@ -649,7 +649,16 @@ public class EasyFarmingOverlay extends Overlay {
                         }
                     } else {
                         // Handle regular items
-                        inventoryItemCounts.put(itemId, itemQuantity);
+
+                        // For some reason ultracompost is retrieved as multiple items of
+                        // quantity 1, so if it exists and is quantity 1 we just accumulate it
+                        if (inventoryItemCounts.containsKey(itemId) && itemQuantity == 1) {
+                            inventoryItemCounts.put(itemId, inventoryItemCounts.get(itemId) + 1);
+                        }
+                        else {
+                            inventoryItemCounts.put(itemId, itemQuantity);
+                        }
+
                     }
                 }
             }


### PR DESCRIPTION
Fix for #54 

Up to you if you want to merge this in seeing as Runelite is returning the dupes with 1 quantity. 

I'm going to continue using this in the meantime and testing it.