### PR TITLE
Add Trimmed Farming Skillcape and Max cape as options

### DIFF
--- a/src/main/java/com/easyfarming/customrun/CustomRunItemRequirements.java
+++ b/src/main/java/com/easyfarming/customrun/CustomRunItemRequirements.java
@@ -183,6 +183,8 @@ public final class CustomRunItemRequirements {
                 into.merge(ItemID.ARDY_CAPE_MEDIUM, quantity, (a, b) -> Math.min(1, a + b));
             } else if (itemId == ItemID.DRAMEN_STAFF) {
                 into.merge(ItemID.DRAMEN_STAFF, quantity, (a, b) -> Math.min(1, a + b));
+            } else if (itemId == ItemID.SKILLCAPE_FARMING || itemId == ItemID.SKILLCAPE_FARMING_TRIMMED || itemId == ItemID.SKILLCAPE_MAX){
+                into.merge(itemId, quantity, (a, b) -> Math.min(1, a + b));
             } else {
                 into.merge(itemId, quantity, Integer::sum);
             }


### PR DESCRIPTION
Noticed my trimmed farming cape was not satisfying the requirement to have it in inventory when using it as the teleport option for Farming Guild.  