### PR TITLE
feat: Expand pay-for-protection to allotment and hops patches

### DIFF
--- a/src/main/java/com/easyfarming/EasyFarmingConfig.java
+++ b/src/main/java/com/easyfarming/EasyFarmingConfig.java
@@ -252,7 +252,8 @@ public interface EasyFarmingConfig extends Config
 		Civitas_Teleport,
 		Civitas_Tele_Tab,
 		Quetzal_whistle,
-		Hunter_Skillcape
+		Hunter_Skillcape,
+		Fairy_Ring
 	}
 	@ConfigItem(
 		position = 11,
@@ -513,7 +514,8 @@ public interface EasyFarmingConfig extends Config
 		Watchtower_Teleport,
 		Yanille,
 		Yanille_Tele_Tab,
-		Normal_POH_Tele_Tab
+		Normal_POH_Tele_Tab,
+		Castle_Wars_Minigame
 	}
 	@ConfigItem(
 			position = 3,

--- a/src/main/java/com/easyfarming/EasyFarmingOverlay.java
+++ b/src/main/java/com/easyfarming/EasyFarmingOverlay.java
@@ -746,7 +746,9 @@ public class EasyFarmingOverlay extends Overlay {
                         }
                     } else {
                         // Handle regular items - sum quantities across slots (e.g. multiple compost)
-                        inventoryItemCounts.put(itemId, inventoryItemCounts.getOrDefault(itemId, 0) + itemQuantity);
+                        // Canonicalize to map noted items to their unnoted equivalents
+                        int canonicalId = itemManager.canonicalize(itemId);
+                        inventoryItemCounts.put(canonicalId, inventoryItemCounts.getOrDefault(canonicalId, 0) + itemQuantity);
                     }
                 }
             }

--- a/src/main/java/com/easyfarming/customrun/LocationCatalog.java
+++ b/src/main/java/com/easyfarming/customrun/LocationCatalog.java
@@ -146,7 +146,7 @@ public class LocationCatalog {
         addTeleports(weiss.getName(), weiss);
         addPatchTypes(weiss.getName(), Arrays.asList(PatchTypes.HERB, PatchTypes.FLOWER, PatchTypes.ALLOTMENT));
 
-        Location civitas = CivitasLocationData.create(config, houseTeleportSupplier);
+        Location civitas = CivitasLocationData.create(config, houseTeleportSupplier, fairyRingSupplier);
         seenNames.add(civitas.getName());
         putLocationForPatch(civitas.getName(), PatchTypes.HERB, civitas);
         putLocationForPatch(civitas.getName(), PatchTypes.FLOWER, civitas);

--- a/src/main/java/com/easyfarming/locations/CivitasLocationData.java
+++ b/src/main/java/com/easyfarming/locations/CivitasLocationData.java
@@ -34,7 +34,8 @@ public class CivitasLocationData {
      *                              (typically from ItemAndLocation.getHouseTeleportItemRequirements())
      * @return A Location instance for Civitas illa Fortis
      */
-    public static Location create(EasyFarmingConfig config, Supplier<List<ItemRequirement>> houseTeleportSupplier) {
+    public static Location create(EasyFarmingConfig config, Supplier<List<ItemRequirement>> houseTeleportSupplier,
+                                  Supplier<List<ItemRequirement>> fairyRingSupplier) {
         Location location = new Location(
             EasyFarmingConfig::enumOptionEnumCivitasTeleport,
             config,
@@ -121,7 +122,21 @@ public class CivitasLocationData {
                 new ItemRequirement(ItemID.SKILLCAPE_HUNTING, 1)
             )
         ));
-        
+
+        // Fairy Ring AJP
+        location.addTeleportOption(new Teleport(
+            "Fairy_Ring",
+            Teleport.Category.FAIRY_RING,
+            "Use a Fairy Ring (AJP) to teleport near Civitas illa Fortis, and run to the patch.",
+            0,
+            "",
+            0,
+            0,
+            6192,
+            CIVITAS_HERB_PATCH_POINT,
+            fairyRingSupplier.get()
+        ));
+
         return location;
     }
 }

--- a/src/main/java/com/easyfarming/locations/hops/YanilleHopsLocationData.java
+++ b/src/main/java/com/easyfarming/locations/hops/YanilleHopsLocationData.java
@@ -102,6 +102,20 @@ public class YanilleHopsLocationData {
             )
         ));
 
+        // Castle Wars Minigame Teleport (Grouping tab) - free, no items required
+        location.addTeleportOption(new Teleport(
+            "Castle_Wars_Minigame",
+            Teleport.Category.ITEM,
+            "Use the Castle Wars minigame teleport from the Grouping tab, and run to Yanille hops patch.",
+            0,
+            "",
+            0,
+            0,
+            9520,
+            YANILLE_HOPS_PATCH_POINT,
+            Collections.emptyList()
+        ));
+
         // Normal POH Tele Tab
         location.addTeleportOption(new Teleport(
             "Normal_POH_Tele_Tab",

--- a/src/main/java/com/easyfarming/overlays/handlers/FarmingStepHandler.java
+++ b/src/main/java/com/easyfarming/overlays/handlers/FarmingStepHandler.java
@@ -27,6 +27,13 @@ public class FarmingStepHandler {
     /** Hint arrow toward the current patch tile when farther than this (tiles); does not gate instructions. */
     private static final int PATCH_HINT_ARROW_RANGE_TILES = 15;
 
+    private static final List<String> ALLOTMENT_FARMER_NAMES = Arrays.asList(
+        "Elstan", "Dantaera", "Kragen", "Marisi", "Lyra", "Alan", "Harminia"
+    );
+    private static final List<String> HOPS_FARMER_NAMES = Arrays.asList(
+        "Vasquen", "Rhonen", "Selena", "Brother Althric", "Ercos"
+    );
+
     private final Client client;
     private final EasyFarmingPlugin plugin;
     private final EasyFarmingConfig config;
@@ -186,43 +193,53 @@ public class FarmingStepHandler {
                     }
                     break;
                 case GROWING:
-                    // Check persistent state FIRST - if already composted, mark as done and return
-                    if (herbPatchComposted) {
-                        herbPatchDone = true;  // Set done flag so transition happens
-                        clearHintArrow();
-                        return;
-                    }
-                    // If already done (shouldn't happen, but safety check)
-                    if (herbPatchDone) {
-                        clearHintArrow();
-                        return;
-                    }
-                    // Check if compost was just applied (from chat message) - this sets herbPatchDone
-                    boolean isComposted = patchStateChecker.patchIsCompostedForHerbPatch();
-                    if (isComposted) {
-                        herbPatchComposted = true;  // Set persistent state
-                        herbPatchDone = true;
-                        // Clear hint arrow when patch is done
-                        clearHintArrow();
-                        // Don't show anything - transition will happen on next frame
-                        return;
-                    }
-                    // Patch is GROWING but not composted yet - show compost instruction
-                    plugin.addTextToInfoBox("Use Compost on patch.");
-                    Integer compostId = itemHighlighter.selectedCompostID();
-                    // If compost is not in inventory, set hint arrow to Tool Leprechaun
-                    if (compostId != null && !itemHighlighter.isItemInInventory(compostId)) {
-                        setHintArrowToNPC("Tool Leprechaun");
+                    if (config.generalPayForProtection() && locationHasAllotmentFarmer(locationName)) {
+                        plugin.addTextToInfoBox("Pay to protect the patch.");
+                        farmerHighlighter.highlightAllotmentFarmers(graphics);
+                        setHintArrowToFirstAvailableNPC(ALLOTMENT_FARMER_NAMES);
+                        if (patchStateChecker.patchIsProtected()) {
+                            herbPatchDone = true;
+                            clearHintArrow();
+                        }
                     } else {
-                        // Clear hint arrow if compost is in inventory (no NPC interaction needed)
-                        clearHintArrow();
+                        // Check persistent state FIRST - if already composted, mark as done and return
+                        if (herbPatchComposted) {
+                            herbPatchDone = true;  // Set done flag so transition happens
+                            clearHintArrow();
+                            return;
+                        }
+                        // If already done (shouldn't happen, but safety check)
+                        if (herbPatchDone) {
+                            clearHintArrow();
+                            return;
+                        }
+                        // Check if compost was just applied (from chat message) - this sets herbPatchDone
+                        boolean isComposted = patchStateChecker.patchIsCompostedForHerbPatch();
+                        if (isComposted) {
+                            herbPatchComposted = true;  // Set persistent state
+                            herbPatchDone = true;
+                            // Clear hint arrow when patch is done
+                            clearHintArrow();
+                            // Don't show anything - transition will happen on next frame
+                            return;
+                        }
+                        // Patch is GROWING but not composted yet - show compost instruction
+                        plugin.addTextToInfoBox("Use Compost on patch.");
+                        Integer compostId = itemHighlighter.selectedCompostID();
+                        // If compost is not in inventory, set hint arrow to Tool Leprechaun
+                        if (compostId != null && !itemHighlighter.isItemInInventory(compostId)) {
+                            setHintArrowToNPC("Tool Leprechaun");
+                        } else {
+                            // Clear hint arrow if compost is in inventory (no NPC interaction needed)
+                            clearHintArrow();
+                        }
+                        if (useSpecificPatch) {
+                            patchHighlighter.highlightSpecificHerbPatch(graphics, patchObjectId, useItemColor);
+                        } else {
+                            patchHighlighter.highlightHerbPatches(graphics, useItemColor);
+                        }
+                        compostHighlighter.highlightCompost(graphics, true, false, false, 1);
                     }
-                    if (useSpecificPatch) {
-                        patchHighlighter.highlightSpecificHerbPatch(graphics, patchObjectId, useItemColor);
-                    } else {
-                        patchHighlighter.highlightHerbPatches(graphics, useItemColor);
-                    }
-                    compostHighlighter.highlightCompost(graphics, true, false, false, 1);
                     break;
                 case UNKNOWN:
                     plugin.addTextToInfoBox("UNKNOWN state: Try to do something with the herb patch to change its state.");
@@ -311,45 +328,66 @@ public class FarmingStepHandler {
                         patchHighlighter.highlightSpecificHopsPatch(graphics, patchObjectId, leftColor);
                         break;
                     case NEEDS_WATER:
-                        plugin.addTextToInfoBox("Water the hops patch.");
-                        patchHighlighter.highlightSpecificHopsPatch(graphics, patchObjectId, useItemColor);
-                        // Highlight all watering can variants
-                        for (int canId : Constants.WATERING_CAN_IDS) {
-                            itemHighlighter.itemHighlight(graphics, canId, useItemColor);
+                        if (config.generalPayForProtection() && locationHasHopsFarmer(locationName)) {
+                            // Pay-for-protection replaces watering
+                            plugin.addTextToInfoBox("Pay to protect the patch.");
+                            farmerHighlighter.highlightHopsFarmers(graphics);
+                            setHintArrowToFirstAvailableNPC(HOPS_FARMER_NAMES);
+                            if (patchStateChecker.patchIsProtected()) {
+                                hopsPatchDone = true;
+                                clearHintArrow();
+                            }
+                        } else {
+                            plugin.addTextToInfoBox("Water the hops patch.");
+                            patchHighlighter.highlightSpecificHopsPatch(graphics, patchObjectId, useItemColor);
+                            // Highlight all watering can variants
+                            for (int canId : Constants.WATERING_CAN_IDS) {
+                                itemHighlighter.itemHighlight(graphics, canId, useItemColor);
+                            }
                         }
                         break;
                     case GROWING:
-                        // Check persistent state FIRST - if already composted, mark as done and return
-                        if (hopsPatchComposted) {
-                            hopsPatchDone = true;  // Set done flag so transition happens
-                            clearHintArrow();
-                            return;
-                        }
-                        // If already done (shouldn't happen, but safety check)
-                        if (hopsPatchDone) {
-                            clearHintArrow();
-                            return;
-                        }
-                        // Check if compost was just applied (from chat message)
-                        boolean isComposted = patchStateChecker.patchIsCompostedForHopsPatch();
-                        if (isComposted) {
-                            hopsPatchComposted = true;  // Set persistent state
-                            hopsPatchDone = true;
-                            clearHintArrow();
-                            return;
-                        }
-                        // Patch is GROWING but not composted yet - show compost instruction
-                        plugin.addTextToInfoBox("Use Compost on patch.");
-                        patchHighlighter.highlightSpecificHopsPatch(graphics, patchObjectId, useItemColor);
-                        Integer compostId = itemHighlighter.selectedCompostID();
-                        // If compost is not in inventory, set hint arrow to Tool Leprechaun
-                        if (compostId != null && !itemHighlighter.isItemInInventory(compostId)) {
-                            setHintArrowToNPC("Tool Leprechaun");
+                        if (config.generalPayForProtection() && locationHasHopsFarmer(locationName)) {
+                            plugin.addTextToInfoBox("Pay to protect the patch.");
+                            farmerHighlighter.highlightHopsFarmers(graphics);
+                            setHintArrowToFirstAvailableNPC(HOPS_FARMER_NAMES);
+                            if (patchStateChecker.patchIsProtected()) {
+                                hopsPatchDone = true;
+                                clearHintArrow();
+                            }
                         } else {
-                            // Clear hint arrow if compost is in inventory (no NPC interaction needed)
-                            clearHintArrow();
+                            // Check persistent state FIRST - if already composted, mark as done and return
+                            if (hopsPatchComposted) {
+                                hopsPatchDone = true;  // Set done flag so transition happens
+                                clearHintArrow();
+                                return;
+                            }
+                            // If already done (shouldn't happen, but safety check)
+                            if (hopsPatchDone) {
+                                clearHintArrow();
+                                return;
+                            }
+                            // Check if compost was just applied (from chat message)
+                            boolean isComposted = patchStateChecker.patchIsCompostedForHopsPatch();
+                            if (isComposted) {
+                                hopsPatchComposted = true;  // Set persistent state
+                                hopsPatchDone = true;
+                                clearHintArrow();
+                                return;
+                            }
+                            // Patch is GROWING but not composted yet - show compost instruction
+                            plugin.addTextToInfoBox("Use Compost on patch.");
+                            patchHighlighter.highlightSpecificHopsPatch(graphics, patchObjectId, useItemColor);
+                            Integer compostId = itemHighlighter.selectedCompostID();
+                            // If compost is not in inventory, set hint arrow to Tool Leprechaun
+                            if (compostId != null && !itemHighlighter.isItemInInventory(compostId)) {
+                                setHintArrowToNPC("Tool Leprechaun");
+                            } else {
+                                // Clear hint arrow if compost is in inventory (no NPC interaction needed)
+                                clearHintArrow();
+                            }
+                            compostHighlighter.highlightCompost(graphics, true, false, false, 1);
                         }
-                        compostHighlighter.highlightCompost(graphics, true, false, false, 1);
                         break;
                     case UNKNOWN:
                         plugin.addTextToInfoBox("UNKNOWN state: Try to do something with the hops patch to change its state.");
@@ -477,29 +515,39 @@ public class FarmingStepHandler {
                         itemHighlighter.highlightFlowerSeeds(graphics);
                         break;
                     case GROWING:
-                        // Check persistent state FIRST - if already composted, mark as done and return
-                        if (flowerPatchComposted) {
-                            flowerPatchDone = true;  // Set done flag so transition happens
-                            clearHintArrow();
-                            return;
+                        if (config.generalPayForProtection() && locationHasAllotmentFarmer(locationName)) {
+                            plugin.addTextToInfoBox("Pay to protect the patch.");
+                            farmerHighlighter.highlightAllotmentFarmers(graphics);
+                            setHintArrowToFirstAvailableNPC(ALLOTMENT_FARMER_NAMES);
+                            if (patchStateChecker.patchIsProtected()) {
+                                flowerPatchDone = true;
+                                clearHintArrow();
+                            }
+                        } else {
+                            // Check persistent state FIRST - if already composted, mark as done and return
+                            if (flowerPatchComposted) {
+                                flowerPatchDone = true;  // Set done flag so transition happens
+                                clearHintArrow();
+                                return;
+                            }
+                            // If already done (shouldn't happen, but safety check)
+                            if (flowerPatchDone) {
+                                clearHintArrow();
+                                return;
+                            }
+                            // Check if compost was just applied (from chat message)
+                            boolean isComposted = patchStateChecker.patchIsCompostedForFlowerPatch();
+                            if (isComposted) {
+                                flowerPatchComposted = true;  // Set persistent state
+                                flowerPatchDone = true;
+                                clearHintArrow();
+                                return;
+                            }
+                            // Patch is GROWING but not composted yet - show compost instruction
+                            plugin.addTextToInfoBox("Use Compost on patch.");
+                            patchHighlighter.highlightSpecificFlowerPatch(graphics, patchObjectId, useItemColor);
+                            compostHighlighter.highlightCompost(graphics, false, false, false, 2);
                         }
-                        // If already done (shouldn't happen, but safety check)
-                        if (flowerPatchDone) {
-                            clearHintArrow();
-                            return;
-                        }
-                        // Check if compost was just applied (from chat message)
-                        boolean isComposted = patchStateChecker.patchIsCompostedForFlowerPatch();
-                        if (isComposted) {
-                            flowerPatchComposted = true;  // Set persistent state
-                            flowerPatchDone = true;
-                            clearHintArrow();
-                            return;
-                        }
-                        // Patch is GROWING but not composted yet - show compost instruction
-                        plugin.addTextToInfoBox("Use Compost on patch.");
-                        patchHighlighter.highlightSpecificFlowerPatch(graphics, patchObjectId, useItemColor);
-                        compostHighlighter.highlightCompost(graphics, false, false, false, 2);
                         break;
                     case UNKNOWN:
                         plugin.addTextToInfoBox("UNKNOWN state: Try to do something with the flower patch to change its state.");
@@ -535,6 +583,7 @@ public class FarmingStepHandler {
             case Constants.REGION_KOUREND:
                 return "Kourend";
             case Constants.REGION_MORYTANIA:
+            case Constants.REGION_MORYTANIA_ALQ:
                 return "Morytania";
             case Constants.REGION_CIVITAS:
                 return "Civitas illa Fortis";
@@ -552,6 +601,26 @@ public class FarmingStepHandler {
         }
     }
     
+    private boolean locationHasAllotmentFarmer(String locationName) {
+        switch (locationName) {
+            case "Harmony Island":
+            case "Troll Stronghold":
+            case "Weiss":
+                return false;
+            default:
+                return true;
+        }
+    }
+
+    private boolean locationHasHopsFarmer(String locationName) {
+        switch (locationName) {
+            case "Unknown":
+                return false;
+            default:
+                return true;
+        }
+    }
+
     /**
      * Gets the fruit tree location name from a region ID.
      * @param regionId The region ID
@@ -682,6 +751,7 @@ public class FarmingStepHandler {
         
         // If this location has no allotment patches, mark as done immediately
         if (allotmentPatchIds == null || allotmentPatchIds.isEmpty()) {
+            plugin.addTextToInfoBox("No allotment patches found (region=" + currentRegionId + " loc=" + locationName + ")");
             this.allotmentPatchDone = true;
             allotmentPatchState.reset();
             return;
@@ -772,7 +842,8 @@ public class FarmingStepHandler {
         
         // Handle early returns in a single place
         if (plantState == AllotmentPatchChecker.PlantState.UNKNOWN) {
-            plugin.addTextToInfoBox("Allotment patch state unknown - north patch");
+            int debugValue = varbitId != -1 ? client.getVarbitValue(varbitId) : -1;
+            plugin.addTextToInfoBox("Allotment patch state unknown - north patch (obj=" + patchObjectId + " varbit=" + varbitId + " val=" + debugValue + ")");
             return;
         }
         
@@ -817,27 +888,37 @@ public class FarmingStepHandler {
                     patchHighlighter.highlightSpecificAllotmentPatch(graphics, patchObjectId, leftColor);
                     break;
                 case GROWING:
-                    // Check if compost was just applied (from chat message)
-                    if (patchStateChecker.patchIsCompostedForAllotmentPatch()) {
-                        // Mark as composted (persistent)
-                        allotmentPatchState.markComposted(0);
-                        // Clear hint arrow when patch is composted
-                        clearHintArrow();
-                        return;
-                    }
-                    // Patch is GROWING but not composted yet - show compost instruction
-                    plugin.addTextToInfoBox("Use Compost on north patch.");
-                    patchHighlighter.highlightSpecificAllotmentPatch(graphics, patchObjectId, useItemColor);
-                    Integer compostId = itemHighlighter.selectedCompostID();
-                    if (compostId != null && itemHighlighter.isItemInInventory(compostId)) {
-                        itemHighlighter.highlightCompost(graphics, compostId, useItemColor);
-                        // Clear hint arrow if compost is in inventory (no NPC interaction needed)
-                        clearHintArrow();
+                    if (config.generalPayForProtection() && locationHasAllotmentFarmer(locationName)) {
+                        plugin.addTextToInfoBox("Pay to protect the north patch.");
+                        farmerHighlighter.highlightAllotmentFarmers(graphics);
+                        setHintArrowToFirstAvailableNPC(ALLOTMENT_FARMER_NAMES);
+                        if (patchStateChecker.patchIsProtected()) {
+                            allotmentPatchState.markComposted(0);
+                            clearHintArrow();
+                        }
                     } else {
-                        compostHighlighter.withdrawCompost(graphics);
-                        // If compost is not in inventory, set hint arrow to Tool Leprechaun
-                        if (compostId != null) {
-                            setHintArrowToNPC("Tool Leprechaun");
+                        // Check if compost was just applied (from chat message)
+                        if (patchStateChecker.patchIsCompostedForAllotmentPatch()) {
+                            // Mark as composted (persistent)
+                            allotmentPatchState.markComposted(0);
+                            // Clear hint arrow when patch is composted
+                            clearHintArrow();
+                            return;
+                        }
+                        // Patch is GROWING but not composted yet - show compost instruction
+                        plugin.addTextToInfoBox("Use Compost on north patch.");
+                        patchHighlighter.highlightSpecificAllotmentPatch(graphics, patchObjectId, useItemColor);
+                        Integer compostId = itemHighlighter.selectedCompostID();
+                        if (compostId != null && itemHighlighter.isItemInInventory(compostId)) {
+                            itemHighlighter.highlightCompost(graphics, compostId, useItemColor);
+                            // Clear hint arrow if compost is in inventory (no NPC interaction needed)
+                            clearHintArrow();
+                        } else {
+                            compostHighlighter.withdrawCompost(graphics);
+                            // If compost is not in inventory, set hint arrow to Tool Leprechaun
+                            if (compostId != null) {
+                                setHintArrowToNPC("Tool Leprechaun");
+                            }
                         }
                     }
                     break;
@@ -967,43 +1048,54 @@ public class FarmingStepHandler {
                     patchHighlighter.highlightSpecificAllotmentPatch(graphics, patchObjectId, leftColor);
                     break;
                 case GROWING:
-                    // This case should only be reached if the patch is GROWING and NOT already composted
-                    // (the early return above should catch GROWING + composted cases)
-                    // Check if compost was just applied (from chat message)
-                    boolean isComposted = patchStateChecker.patchIsCompostedForAllotmentPatch();
-                    if (isComposted) {
-                        // Mark as composted (persistent)
-                        allotmentPatchState.markComposted(1);
-                        // Clear hint arrow when patch is composted
-                        clearHintArrow();
-                        return;
-                    }
-                    // Safety check: If already composted (shouldn't reach here due to early return, but just in case)
-                    if (allotmentPatchState.isPatchComposted(1)) {
-                        // Patch is already composted, mark as completed and return
-                        if (!allotmentPatchState.isPatchCompleted(1)) {
-                            allotmentPatchState.setPatchCompleted(1, true);
+                    if (config.generalPayForProtection() && locationHasAllotmentFarmer(locationName)) {
+                        plugin.addTextToInfoBox("Pay to protect the south patch.");
+                        farmerHighlighter.highlightAllotmentFarmers(graphics);
+                        setHintArrowToFirstAvailableNPC(ALLOTMENT_FARMER_NAMES);
+                        if (patchStateChecker.patchIsProtected()) {
+                            allotmentPatchState.markComposted(1);
+                            clearHintArrow();
                         }
-                        return; // Don't show compost instruction if already composted
-                    }
-                    // Patch is GROWING but not composted yet - show compost instruction
-                    plugin.addTextToInfoBox("Use Compost on south patch.");
-                    patchHighlighter.highlightSpecificAllotmentPatch(graphics, patchObjectId, useItemColor);
-                    Integer compostId = itemHighlighter.selectedCompostID();
-                    if (compostId != null && itemHighlighter.isItemInInventory(compostId)) {
-                        itemHighlighter.highlightCompost(graphics, compostId, useItemColor);
-                        // Clear hint arrow if compost is in inventory (no NPC interaction needed)
-                        clearHintArrow();
                     } else {
-                        compostHighlighter.withdrawCompost(graphics);
-                        // If compost is not in inventory, set hint arrow to Tool Leprechaun
-                        if (compostId != null) {
-                            setHintArrowToNPC("Tool Leprechaun");
+                        // This case should only be reached if the patch is GROWING and NOT already composted
+                        // (the early return above should catch GROWING + composted cases)
+                        // Check if compost was just applied (from chat message)
+                        boolean isComposted = patchStateChecker.patchIsCompostedForAllotmentPatch();
+                        if (isComposted) {
+                            // Mark as composted (persistent)
+                            allotmentPatchState.markComposted(1);
+                            // Clear hint arrow when patch is composted
+                            clearHintArrow();
+                            return;
+                        }
+                        // Safety check: If already composted (shouldn't reach here due to early return, but just in case)
+                        if (allotmentPatchState.isPatchComposted(1)) {
+                            // Patch is already composted, mark as completed and return
+                            if (!allotmentPatchState.isPatchCompleted(1)) {
+                                allotmentPatchState.setPatchCompleted(1, true);
+                            }
+                            return; // Don't show compost instruction if already composted
+                        }
+                        // Patch is GROWING but not composted yet - show compost instruction
+                        plugin.addTextToInfoBox("Use Compost on south patch.");
+                        patchHighlighter.highlightSpecificAllotmentPatch(graphics, patchObjectId, useItemColor);
+                        Integer compostId = itemHighlighter.selectedCompostID();
+                        if (compostId != null && itemHighlighter.isItemInInventory(compostId)) {
+                            itemHighlighter.highlightCompost(graphics, compostId, useItemColor);
+                            // Clear hint arrow if compost is in inventory (no NPC interaction needed)
+                            clearHintArrow();
+                        } else {
+                            compostHighlighter.withdrawCompost(graphics);
+                            // If compost is not in inventory, set hint arrow to Tool Leprechaun
+                            if (compostId != null) {
+                                setHintArrowToNPC("Tool Leprechaun");
+                            }
                         }
                     }
                     break;
                 case UNKNOWN:
-                    plugin.addTextToInfoBox("UNKNOWN state: Try to do something with the south allotment patch to change its state.");
+                    int debugValue = varbitId != -1 ? client.getVarbitValue(varbitId) : -1;
+                    plugin.addTextToInfoBox("UNKNOWN state: south patch (obj=" + patchObjectId + " varbit=" + varbitId + " val=" + debugValue + ")");
                     break;
             }
         }

--- a/src/main/java/com/easyfarming/overlays/handlers/FarmingStepHandler.java
+++ b/src/main/java/com/easyfarming/overlays/handlers/FarmingStepHandler.java
@@ -764,7 +764,7 @@ public class FarmingStepHandler {
         
         // If this location has no allotment patches, mark as done immediately
         if (allotmentPatchIds == null || allotmentPatchIds.isEmpty()) {
-            plugin.addTextToInfoBox("No allotment patches found (region=" + currentRegionId + " loc=" + locationName + ")");
+            // No allotment patches at this location, skip
             this.allotmentPatchDone = true;
             allotmentPatchState.reset();
             return;
@@ -855,8 +855,7 @@ public class FarmingStepHandler {
 
         // Handle early returns in a single place
         if (plantState == AllotmentPatchChecker.PlantState.UNKNOWN) {
-            int debugValue = varbitId != -1 ? client.getVarbitValue(varbitId) : -1;
-            plugin.addTextToInfoBox("Allotment patch state unknown - north patch (obj=" + patchObjectId + " varbit=" + varbitId + " val=" + debugValue + ")");
+            plugin.addTextToInfoBox("Allotment patch state unknown - north patch");
             return;
         }
         
@@ -1107,8 +1106,7 @@ public class FarmingStepHandler {
                     }
                     break;
                 case UNKNOWN:
-                    int debugValue = varbitId != -1 ? client.getVarbitValue(varbitId) : -1;
-                    plugin.addTextToInfoBox("UNKNOWN state: south patch (obj=" + patchObjectId + " varbit=" + varbitId + " val=" + debugValue + ")");
+                    plugin.addTextToInfoBox("UNKNOWN state: Try to do something with the south allotment patch to change its state.");
                     break;
             }
         }

--- a/src/main/java/com/easyfarming/overlays/handlers/FarmingStepHandler.java
+++ b/src/main/java/com/easyfarming/overlays/handlers/FarmingStepHandler.java
@@ -586,6 +586,8 @@ public class FarmingStepHandler {
             case Constants.REGION_MORYTANIA_ALQ:
                 return "Morytania";
             case Constants.REGION_CIVITAS:
+            case Constants.REGION_CIVITAS_ALT:
+            case Constants.REGION_CIVITAS_ALT2:
                 return "Civitas illa Fortis";
             case Constants.REGION_HARMONY:
                 return "Harmony Island";
@@ -829,7 +831,7 @@ public class FarmingStepHandler {
         
         // Check state for north patch
         AllotmentPatchChecker.PlantState plantState = AllotmentPatchChecker.PlantState.UNKNOWN;
-        
+
         if (varbitId != -1) {
             plantState = AllotmentPatchChecker.checkAllotmentPatch(client, varbitId);
         }
@@ -839,7 +841,7 @@ public class FarmingStepHandler {
         // Only GROWING + composted is considered completed (nothing more to do)
         boolean completed = plantState == AllotmentPatchChecker.PlantState.GROWING && allotmentPatchState.isPatchComposted(0);
         allotmentPatchState.setPatchCompleted(0, completed);
-        
+
         // Handle early returns in a single place
         if (plantState == AllotmentPatchChecker.PlantState.UNKNOWN) {
             int debugValue = varbitId != -1 ? client.getVarbitValue(varbitId) : -1;

--- a/src/main/java/com/easyfarming/overlays/handlers/NavigationHandler.java
+++ b/src/main/java/com/easyfarming/overlays/handlers/NavigationHandler.java
@@ -198,6 +198,8 @@ public class NavigationHandler {
                 return areaCheck.isPlayerWithinArea(new WorldPoint(2936, 3438, 0), 10);
             case "Varrock":
                 return areaCheck.isPlayerWithinArea(new WorldPoint(3229, 3459, 0), 10);
+            case "Morytania":
+                return areaCheck.isPlayerWithinArea(new WorldPoint(3601, 3525, 0), 10);
             // Hops locations
             case "Seers Village":
                 return areaCheck.isPlayerWithinArea(new WorldPoint(2667, 3526, 0), 10);

--- a/src/main/java/com/easyfarming/overlays/highlighting/FarmerHighlighter.java
+++ b/src/main/java/com/easyfarming/overlays/highlighting/FarmerHighlighter.java
@@ -65,6 +65,34 @@ public class FarmerHighlighter {
             "Nikkie"   // Farming Guild
         ));
     }
+
+    /**
+     * Highlights allotment/herb/flower farmers.
+     * These patch types share the same farmer NPC at each location.
+     */
+    public void highlightAllotmentFarmers(Graphics2D graphics) {
+        highlightFarmers(graphics, Arrays.asList(
+            "Elstan",   // Falador
+            "Dantaera", // Catherby
+            "Kragen",   // Ardougne
+            "Marisi",   // Kourend
+            "Lyra",     // Morytania
+            "Alan"      // Farming Guild
+        ));
+    }
+
+    /**
+     * Highlights hops farmers.
+     */
+    public void highlightHopsFarmers(Graphics2D graphics) {
+        highlightFarmers(graphics, Arrays.asList(
+            "Vasquen",         // Lumbridge
+            "Rhonen",          // Seers Village
+            "Selena",          // Yanille
+            "Brother Althric", // Entrana
+            "Ercos"            // Aldarin
+        ));
+    }
     
     private boolean isInterfaceOpen(int groupId, int childId) {
         Widget widget = client.getWidget(groupId, childId);

--- a/src/main/java/com/easyfarming/overlays/highlighting/ItemHighlighter.java
+++ b/src/main/java/com/easyfarming/overlays/highlighting/ItemHighlighter.java
@@ -330,6 +330,9 @@ public class ItemHighlighter {
             if (checkItemId == itemId) {
                 return true;
             }
+            if (itemManager != null && itemManager.canonicalize(checkItemId) == itemId) {
+                return true;
+            }
             // Special handling for bottomless compost bucket - check filled variants
             if (itemId == ItemID.BOTTOMLESS_COMPOST_BUCKET) {
                 // Check for all bottomless bucket variants (empty: BOTTOMLESS_COMPOST_BUCKET, 

--- a/src/main/java/com/easyfarming/overlays/utils/PatchStateChecker.java
+++ b/src/main/java/com/easyfarming/overlays/utils/PatchStateChecker.java
@@ -1,6 +1,8 @@
 package com.easyfarming.overlays.utils;
 
 import com.easyfarming.EasyFarmingPlugin;
+import net.runelite.api.Client;
+import net.runelite.api.widgets.Widget;
 
 import javax.inject.Inject;
 import java.util.regex.Pattern;
@@ -9,6 +11,8 @@ import java.util.regex.Pattern;
  * Utility class for checking patch states (composted, protected, etc.).
  */
 public class PatchStateChecker {
+    private static final int DIALOG_NPC_GROUP_ID = 231;
+    private static final int DIALOG_NPC_TEXT_CHILD_ID = 6;
     private static final String REGEX_COMPOST1 = "You treat the (herb patch|flower patch|allotment|tree patch|fruit tree patch|hops patch) with (compost|supercompost|ultracompost)\\.";
     private static final String REGEX_COMPOST2 = "This (herb patch|flower patch|allotment|tree patch|fruit tree patch|hops patch) has already been treated with (compost|supercompost|ultracompost)\\.";
     private static final String REGEX_COMPOST3 = "You treat the patch with (compost|supercompost|ultracompost)\\.";
@@ -17,13 +21,19 @@ public class PatchStateChecker {
     
     private static final String STANDARD_RESPONSE = "You pay the gardener ([0-9A-Za-z\\ ]+) to protect the patch\\.";
     private static final String FALADOR_ELITE_RESPONSE = "The gardener protects your tree for you, free of charge, as a token of gratitude for completing the ([A-Za-z\\ ]+)\\.";
-    private static final Pattern PROTECTED_PATTERN = Pattern.compile(STANDARD_RESPONSE + "|" + FALADOR_ELITE_RESPONSE);
+    private static final String ALREADY_PROTECTED_RESPONSE = "I'm already looking after that patch for you\\.";
+    private static final Pattern PROTECTED_PATTERN = Pattern.compile(STANDARD_RESPONSE + "|" + FALADOR_ELITE_RESPONSE + "|" + ALREADY_PROTECTED_RESPONSE);
     
     private final EasyFarmingPlugin plugin;
-    
+    private final Client client;
+
+    // Track consumed dialog text so the same dialog isn't used for multiple patches
+    private String lastConsumedDialogText = null;
+
     @Inject
-    public PatchStateChecker(EasyFarmingPlugin plugin) {
+    public PatchStateChecker(EasyFarmingPlugin plugin, Client client) {
         this.plugin = plugin;
+        this.client = client;
     }
     
     /**
@@ -189,15 +199,36 @@ public class PatchStateChecker {
     }
     
     /**
-     * Checks if a patch has been protected based on chat messages.
+     * Checks if a patch has been protected based on chat messages or NPC dialog.
      */
     public boolean patchIsProtected() {
         String lastMessage = plugin.getLastMessage();
-        if (lastMessage == null || lastMessage.isEmpty()) {
-            return false;
+        if (lastMessage != null && !lastMessage.isEmpty()) {
+            if (PROTECTED_PATTERN.matcher(lastMessage).matches()) {
+                // Clear the message so it isn't consumed by another patch at the same location
+                plugin.clearLastMessage();
+                return true;
+            }
         }
-        
-        return PROTECTED_PATTERN.matcher(lastMessage).matches();
+
+        // Check NPC dialog widget for "already looking after" response
+        Widget dialogWidget = client.getWidget(DIALOG_NPC_GROUP_ID, DIALOG_NPC_TEXT_CHILD_ID);
+        if (dialogWidget != null && !dialogWidget.isHidden()) {
+            String dialogText = dialogWidget.getText();
+            if (dialogText != null && PROTECTED_PATTERN.matcher(dialogText).matches()) {
+                // Don't consume the same dialog text twice (e.g., north + south allotment)
+                if (dialogText.equals(lastConsumedDialogText)) {
+                    return false;
+                }
+                lastConsumedDialogText = dialogText;
+                return true;
+            }
+        } else {
+            // Dialog closed — reset so future dialogs can be detected
+            lastConsumedDialogText = null;
+        }
+
+        return false;
     }
 }
 

--- a/src/main/java/com/easyfarming/utils/Constants.java
+++ b/src/main/java/com/easyfarming/utils/Constants.java
@@ -22,6 +22,7 @@ public class Constants {
     public static final int REGION_HARMONY = 15148;
     public static final int REGION_KOUREND = 6967;
     public static final int REGION_MORYTANIA = 14391;
+    public static final int REGION_MORYTANIA_ALQ = 14390; // ALQ fairy ring landing area (south of patch region boundary)
     public static final int REGION_TROLL_STRONGHOLD = 11321;
     public static final int REGION_WEISS = 11325;
     public static final int REGION_CIVITAS = 6192;

--- a/src/main/java/com/easyfarming/utils/Constants.java
+++ b/src/main/java/com/easyfarming/utils/Constants.java
@@ -26,6 +26,8 @@ public class Constants {
     public static final int REGION_TROLL_STRONGHOLD = 11321;
     public static final int REGION_WEISS = 11325;
     public static final int REGION_CIVITAS = 6192;
+    public static final int REGION_CIVITAS_ALT = 6448;  // Region south of patches (fairy ring approach path)
+    public static final int REGION_CIVITAS_ALT2 = 6447; // Region near AJP fairy ring
     public static final int REGION_GNOME_STRONGHOLD = 9782;
     public static final int REGION_GNOME_STRONGHOLD_ALT = 9781;
     


### PR DESCRIPTION
> **Note:** Not all patch locations have been tested in-game due to limitations of my current OSRS account which is pretty new. Farmer names and dialog detection are based on wiki data and may need adjustments for untested locations.

## Summary

Expands pay-for-protection support beyond tree/fruit tree patches to cover **herb**, **flower**, **allotment**, and **hops** patches.

### Pay-for-protection: Herb patches
- Highlights nearby allotment farmers when a herb patch is growing
- Same dialog detection and protection flow as tree/fruit tree patches

### Pay-for-protection: Flower patches
- Highlights nearby allotment farmers when a flower patch is growing
- Same dialog detection and protection flow as herb patches

### Pay-for-protection: Allotment patches
- Highlights nearby allotment farmers (Elstan, Dantaera, Kragen, Marisi, Lyra, Alan, Harminia) when a patch is growing
- Detects "I'm already looking after that patch for you" NPC dialog to confirm protection
- Tracks dialog consumption to prevent the same dialog satisfying both north and south allotment patches

### Pay-for-protection: Hops patches
- Highlights nearby hops farmers (Vasquen, Rhonen, Selena, Brother Althric, Ercos) when a patch is growing
- Same dialog detection and protection flow as allotment patches

### Other changes
- Added Fairy Ring teleport option for Civitas illa Fortis
- Added Castle Wars Minigame teleport option for Yanille hops
- Fixed noted item detection by canonicalizing item IDs in inventory count

## Test plan

- [ ] Run a herb run with pay-for-protection enabled, verify farmer highlighting
- [ ] Run a flower run with pay-for-protection enabled, verify farmer highlighting
- [ ] Run an allotment run with pay-for-protection enabled, verify farmer highlighting and dialog detection at multiple locations
- [ ] Run a hops run with pay-for-protection enabled, verify farmer highlighting
- [ ] Verify north-to-south allotment transition works when both patches are already protected (dialog not consumed twice)
