### PR TITLE
Add Fertile Soil support + Herb sack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Highlights and Overlays to make farming runs easier.
 
 ### Extensive Configuration
 - **Location toggles** - Enable/disable specific patches based on your requirements
-- **Compost selection** - Choose between regular, super, ultra, or bottomless compost
+- **Compost selection** - Choose between regular, super, ultra, bottomless, or Fertile Soil composting
+- **Fertile Soil routing** - Avoid standard spellbook teleports automatically, or opt into Spellbook Swap support
 - **Tool preferences** - Optional rake and seed dibber inclusion
 - **Limpwurt support** - Include limpwurt seeds in herb runs where applicable
 

--- a/src/main/java/com/easyfarming/EasyFarmingConfig.java
+++ b/src/main/java/com/easyfarming/EasyFarmingConfig.java
@@ -71,10 +71,23 @@ public interface EasyFarmingConfig extends Config
 
 	enum OptionEnumCompost
 	{
-		Compost,
-		Supercompost,
-		Ultracompost,
-		Bottomless
+		Compost("Compost"),
+		Supercompost("Supercompost"),
+		Ultracompost("Ultracompost"),
+		Bottomless("Bottomless"),
+		Fertile_Soil("Fertile Soil"),
+		Fertile_Soil_Ash_Covered_Tome("FS + Tome");
+
+		private final String displayName;
+
+		OptionEnumCompost(String displayName) {
+			this.displayName = displayName;
+		}
+
+		@Override
+		public String toString() {
+			return displayName;
+		}
 	}
 	@ConfigItem(
 			position = 5,
@@ -85,11 +98,36 @@ public interface EasyFarmingConfig extends Config
 	)
 	default OptionEnumCompost enumConfigCompost() { return OptionEnumCompost.Bottomless; }
 
+	enum OptionEnumFertileSoilTeleportMode
+	{
+		Avoid_standard_spellbook_teleports("Avoid spells"),
+		Use_Spellbook_Swap("Use Swap");
+
+		private final String displayName;
+
+		OptionEnumFertileSoilTeleportMode(String displayName) {
+			this.displayName = displayName;
+		}
+
+		@Override
+		public String toString() {
+			return displayName;
+		}
+	}
+	@ConfigItem(
+			position = 6,
+			keyName = "fertileSoilTeleportMode",
+			name = "FS teleports",
+			description = "How to handle standard spellbook teleports while using Fertile Soil",
+			section = generalList
+	)
+	default OptionEnumFertileSoilTeleportMode fertileSoilTeleportMode() { return OptionEnumFertileSoilTeleportMode.Avoid_standard_spellbook_teleports; }
+
 	@ConfigItem(
 		keyName = "booleanConfigPayForProtection",
 		name = "Pay for protection",
 		description = "Want a reminder to pay for protection? (This currently doesn't check for the required items, only prompts you to pay the farmer.)",
-		position = 6,
+		position = 7,
 		section = generalList
 	)
 	default boolean generalPayForProtection() { return false; }

--- a/src/main/java/com/easyfarming/EasyFarmingConfig.java
+++ b/src/main/java/com/easyfarming/EasyFarmingConfig.java
@@ -124,10 +124,19 @@ public interface EasyFarmingConfig extends Config
 	default OptionEnumFertileSoilTeleportMode fertileSoilTeleportMode() { return OptionEnumFertileSoilTeleportMode.Avoid_standard_spellbook_teleports; }
 
 	@ConfigItem(
+			position = 7,
+			keyName = "useHerbSack",
+			name = "Use herb sack",
+			description = "Require a herb sack or silklined herb sack for herb runs",
+			section = generalList
+	)
+	default boolean useHerbSack() { return false; }
+
+	@ConfigItem(
 		keyName = "booleanConfigPayForProtection",
 		name = "Pay for protection",
 		description = "Want a reminder to pay for protection? (This currently doesn't check for the required items, only prompts you to pay the farmer.)",
-		position = 7,
+		position = 8,
 		section = generalList
 	)
 	default boolean generalPayForProtection() { return false; }

--- a/src/main/java/com/easyfarming/EasyFarmingOverlay.java
+++ b/src/main/java/com/easyfarming/EasyFarmingOverlay.java
@@ -1,16 +1,20 @@
 package com.easyfarming;
 
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.awt.Rectangle;
 import java.util.*;
 import java.util.HashSet;
 import java.util.Set;
 import javax.inject.Inject;
 
 import net.runelite.api.*;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.VarbitID;
+import net.runelite.api.widgets.Widget;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -100,6 +104,18 @@ public class EasyFarmingOverlay extends Overlay {
 
     public boolean isArdyCloak(int itemId) {
         return ARDY_CLOAK_IDS.contains(itemId);
+    }
+
+    public static final List<Integer> FARMING_CAPE_IDS = Arrays.asList(ItemID.SKILLCAPE_FARMING,
+            ItemID.SKILLCAPE_FARMING_TRIMMED);
+    private static final int BASE_FARMING_CAPE_ID = ItemID.SKILLCAPE_FARMING;
+
+    public List<Integer> getFarmingCapeIds() {
+        return FARMING_CAPE_IDS;
+    }
+
+    public boolean isFarmingCape(int itemId) {
+        return FARMING_CAPE_IDS.contains(itemId);
     }
 
     public static final List<Integer> WATERING_CAN_IDS = Constants.WATERING_CAN_IDS;
@@ -274,13 +290,110 @@ public class EasyFarmingOverlay extends Overlay {
         return FRUIT_TREE_SAPLING_IDS.contains(itemId);
     }
 
-    public static final List<Integer> RUNE_POUCH_ID = Arrays.asList(ItemID.BH_RUNE_POUCH, ItemID.DIVINE_RUNE_POUCH);
+    public static final List<Integer> RUNE_POUCH_ID = Arrays.asList(
+            ItemID.BH_RUNE_POUCH, ItemID.BH_RUNE_POUCH_TROUVER,
+            ItemID.DIVINE_RUNE_POUCH, ItemID.DIVINE_RUNE_POUCH_TROUVER);
 
     public static final List<Integer> RUNE_POUCH_AMOUNT_VARBITS = Arrays.asList(VarbitID.RUNE_POUCH_QUANTITY_1,
             VarbitID.RUNE_POUCH_QUANTITY_2, VarbitID.RUNE_POUCH_QUANTITY_3, VarbitID.RUNE_POUCH_QUANTITY_4);
 
     public static final List<Integer> RUNE_POUCH_RUNE_VARBITS = Arrays.asList(VarbitID.RUNE_POUCH_TYPE_1,
             VarbitID.RUNE_POUCH_TYPE_2, VarbitID.RUNE_POUCH_TYPE_3, VarbitID.RUNE_POUCH_TYPE_4);
+
+    public static final List<Integer> SEED_BOX_IDS = Constants.SEED_BOX_IDS;
+
+    public List<Integer> getSeedBoxIds() {
+        return SEED_BOX_IDS;
+    }
+
+    public boolean isSeedBox(int itemId) {
+        return Constants.isSeedBox(itemId);
+    }
+
+    /**
+     * True once the client has received the Seed Box item container this session.
+     * {@link Client#getItemContainer(int)} is {@code @Nullable}: null means contents are unknown
+     * (not the same as a known-empty box, which returns a non-null container).
+     */
+    private boolean isSeedBoxContentsKnown() {
+        return client.getItemContainer(InventoryID.SEED_BOX) != null;
+    }
+
+    /**
+     * Seeds stored in the Seed Box ({@link InventoryID#SEED_BOX}).
+     * Returns an empty array when the container has not been received yet (unknown) or has no items.
+     */
+    private Item[] getSeedBoxItems() {
+        ItemContainer seedBox = client.getItemContainer(InventoryID.SEED_BOX);
+        if (seedBox == null || seedBox.getItems() == null) {
+            return new Item[0];
+        }
+        return seedBox.getItems();
+    }
+
+    private boolean inventoryContainsSeedBox(Item[] items) {
+        for (Item item : items) {
+            if (item != null && isSeedBox(item.getId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Aggregate / specific seed IDs used as custom-run requirements (not saplings). */
+    private boolean isSeedRequirementItemId(int itemId) {
+        return itemId == BASE_SEED_ID
+                || itemId == ItemID.LIMPWURT_SEED
+                || itemId == BASE_ALLOTMENT_SEED_ID
+                || itemId == BASE_HOPS_SEED_ID
+                || isHerbSeed(itemId)
+                || isFlowerSeed(itemId)
+                || isAllotmentSeed(itemId)
+                || isHopsSeed(itemId);
+    }
+
+    /** Highlights Seed Box inventory slots (Check action) using the use-item highlight color. */
+    private void highlightSeedBoxInInventory(Graphics2D graphics, Item[] items) {
+        EasyFarmingConfig config = plugin.getConfig();
+        if (config == null) {
+            return;
+        }
+        Color color = new Color(
+                config.highlightUseItemColor().getRed(),
+                config.highlightUseItemColor().getGreen(),
+                config.highlightUseItemColor().getBlue(),
+                config.highlightAlpha());
+        Widget inventoryWidget = client.getWidget(InterfaceID.INVENTORY);
+        if (inventoryWidget == null) {
+            inventoryWidget = client.getWidget(149, 0);
+        }
+        if (inventoryWidget == null) {
+            return;
+        }
+        Widget[] children = inventoryWidget.getChildren();
+        Widget[] dynamicChildren = inventoryWidget.getDynamicChildren();
+        Widget[] childrenToUse = (dynamicChildren != null && dynamicChildren.length > 0) ? dynamicChildren : children;
+        if (childrenToUse == null) {
+            return;
+        }
+        for (int i = 0; i < items.length && i < childrenToUse.length; i++) {
+            Item item = items[i];
+            if (item == null || !isSeedBox(item.getId())) {
+                continue;
+            }
+            Widget itemWidget = childrenToUse[i];
+            if (itemWidget == null) {
+                continue;
+            }
+            Rectangle bounds = itemWidget.getBounds();
+            if (bounds != null && bounds.width > 0 && bounds.height > 0) {
+                graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), 100));
+                graphics.fill(bounds);
+                graphics.setColor(color);
+                graphics.draw(bounds);
+            }
+        }
+    }
 
     private static final Map<Integer, List<Integer>> COMBINATION_RUNE_SUBRUNES_MAP;
 
@@ -348,7 +461,8 @@ public class EasyFarmingOverlay extends Overlay {
         // Twinflame Staff (Fire + Water)
         staffMap.put(ItemID.TWINFLAME_STAFF, Arrays.asList(ItemID.FIRERUNE, ItemID.WATERRUNE));
 
-        // Tome of Earth (Earth) — charged variant provides runes in this mapping
+        // Tomes — charged variants only (empty/uncharged do not provide runes)
+        staffMap.put(ItemID.TOME_OF_FIRE, Arrays.asList(ItemID.FIRERUNE));
         staffMap.put(ItemID.TOME_OF_EARTH, Arrays.asList(ItemID.EARTHRUNE));
 
         STAFF_RUNES_MAP = Collections.unmodifiableMap(staffMap);
@@ -616,9 +730,6 @@ public class EasyFarmingOverlay extends Overlay {
 
         if (!plugin.areItemsCollected()) {
             boolean needsLunarSpellbook = FertileSoilHelper.needsLunarSpellbook(client, plugin.getConfig());
-            plugin.addTextToInfoBox(needsLunarSpellbook
-                    ? FertileSoilHelper.SWITCH_TO_LUNAR_SPELLBOOK_INSTRUCTION
-                    : "Grab all the items needed");
             // List of items to check
             Map<Integer, Integer> itemsToCheck = null;
             if (plugin.getFarmingTeleportOverlay().isCustomRunMode()
@@ -709,8 +820,25 @@ public class EasyFarmingOverlay extends Overlay {
             int totalHopsSeeds = 0;
             int totalFlowerSeeds = 0;
             boolean customRun = plugin.getFarmingTeleportOverlay().isCustomRunMode();
+            // First-class Seed Box state: null container = unknown; non-null = known (possibly empty).
+            boolean seedBoxContentsUnknown = inventoryContainsSeedBox(items) && !isSeedBoxContentsKnown();
+            Item[] seedBoxItems = getSeedBoxItems();
             if (customRun) {
                 for (Item item : items) {
+                    if (isHerbSeed(item.getId())) {
+                        totalSeeds += item.getQuantity();
+                    }
+                    if (isAllotmentSeed(item.getId())) {
+                        totalAllotmentSeeds += item.getQuantity();
+                    }
+                    if (isFlowerSeed(item.getId())) {
+                        totalFlowerSeeds += item.getQuantity();
+                    }
+                }
+                for (Item item : seedBoxItems) {
+                    if (item == null) {
+                        continue;
+                    }
                     if (isHerbSeed(item.getId())) {
                         totalSeeds += item.getQuantity();
                     }
@@ -739,6 +867,11 @@ public class EasyFarmingOverlay extends Overlay {
             if (customRun) {
                 for (Item item : items) {
                     if (isHopsSeed(item.getId())) {
+                        totalHopsSeeds += item.getQuantity();
+                    }
+                }
+                for (Item item : seedBoxItems) {
+                    if (item != null && isHopsSeed(item.getId())) {
                         totalHopsSeeds += item.getQuantity();
                     }
                 }
@@ -795,6 +928,17 @@ public class EasyFarmingOverlay extends Overlay {
                 }
             }
 
+            // Seed box contents (InventoryID.SEED_BOX) count toward seed requirements
+            for (Item seedBoxItem : seedBoxItems) {
+                if (seedBoxItem == null || seedBoxItem.getId() < 0) {
+                    continue;
+                }
+                int seedBoxItemId = seedBoxItem.getId();
+                int seedBoxQty = seedBoxItem.getQuantity();
+                inventoryItemCounts.put(seedBoxItemId,
+                        inventoryItemCounts.getOrDefault(seedBoxItemId, 0) + seedBoxQty);
+            }
+
             // Third pass: add equipped items to inventory counts
             // Note: equippedItems was already retrieved above for skills necklace charges
             for (Map.Entry<Integer, Integer> equippedEntry : equippedItems.entrySet()) {
@@ -819,6 +963,7 @@ public class EasyFarmingOverlay extends Overlay {
 
             List<AbstractMap.SimpleEntry<Integer, Integer>> missingItemsWithCounts = new ArrayList<>();
             boolean allItemsCollected = true;
+            boolean unmetSeedRequirement = false;
             for (Map.Entry<Integer, Integer> entry : itemsToCheck.entrySet()) {
                 int itemId = entry.getKey();
                 int count = entry.getValue();
@@ -900,6 +1045,17 @@ public class EasyFarmingOverlay extends Overlay {
                         }
                     }
                     inventoryCount = hasArdyCloak ? 1 : 0;
+                } else if (itemId == BASE_FARMING_CAPE_ID) {
+                    // Check if any Farming cape variant (untrimmed or trimmed) is equipped or in inventory
+                    // inventoryItemCounts already includes equipped items from the third pass
+                    boolean hasFarmingCape = false;
+                    for (int capeId : FARMING_CAPE_IDS) {
+                        if (inventoryItemCounts.containsKey(capeId) && inventoryItemCounts.get(capeId) > 0) {
+                            hasFarmingCape = true;
+                            break;
+                        }
+                    }
+                    inventoryCount = hasFarmingCape ? 1 : 0;
                 } else if (itemId == BASE_WATERING_CAN_ID) {
                     // Check if any watering can variant is equipped or in inventory
                     // inventoryItemCounts already includes equipped items from the third pass
@@ -922,9 +1078,18 @@ public class EasyFarmingOverlay extends Overlay {
                 }
 
                 // Rune pouch contents are already included in inventoryItemCounts
+                // Seed box contents are already included in inventoryItemCounts / seed totals
+                // (when unknown, getSeedBoxItems() is empty so totals are inventory-only)
 
                 if (inventoryCount < count) {
                     allItemsCollected = false;
+                    if (isSeedRequirementItemId(itemId)) {
+                        unmetSeedRequirement = true;
+                        // Contents may be in the Seed Box — defer seed missing-UI until known.
+                        if (seedBoxContentsUnknown) {
+                            continue;
+                        }
+                    }
                     int missingCount = count - inventoryCount;
                     BufferedImage itemImage = itemManager.getImage(itemId);
                     if (itemImage != null) {
@@ -932,6 +1097,19 @@ public class EasyFarmingOverlay extends Overlay {
                         missingItemsWithCounts.add(new AbstractMap.SimpleEntry<>(itemId, missingCount));
                     }
                 }
+            }
+
+            // Prompt Check only when the box is present/unknown AND the requirement pass
+            // already found unmet seed requirements (no parallel recount).
+            boolean promptCheckSeedBox = seedBoxContentsUnknown && unmetSeedRequirement;
+            if (needsLunarSpellbook) {
+                plugin.addTextToInfoBox(FertileSoilHelper.SWITCH_TO_LUNAR_SPELLBOOK_INSTRUCTION);
+            } else if (promptCheckSeedBox) {
+                plugin.addTextToInfoBox("Check the Seed Box to read its contents");
+                highlightSeedBoxInInventory(graphics, items);
+                allItemsCollected = false;
+            } else {
+                plugin.addTextToInfoBox("Grab all the items needed");
             }
 
             // Sort missing items: tools first, then teleport items (basalts last among

--- a/src/main/java/com/easyfarming/EasyFarmingOverlay.java
+++ b/src/main/java/com/easyfarming/EasyFarmingOverlay.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 
 import com.easyfarming.customrun.CustomRunItemRequirements;
 import com.easyfarming.utils.Constants;
+import com.easyfarming.utils.FertileSoilHelper;
 
 public class EasyFarmingOverlay extends Overlay {
 
@@ -614,7 +615,10 @@ public class EasyFarmingOverlay extends Overlay {
         }
 
         if (!plugin.areItemsCollected()) {
-            plugin.addTextToInfoBox("Grab all the items needed");
+            boolean needsLunarSpellbook = FertileSoilHelper.needsLunarSpellbook(client, plugin.getConfig());
+            plugin.addTextToInfoBox(needsLunarSpellbook
+                    ? FertileSoilHelper.SWITCH_TO_LUNAR_SPELLBOOK_INSTRUCTION
+                    : "Grab all the items needed");
             // List of items to check
             Map<Integer, Integer> itemsToCheck = null;
             if (plugin.getFarmingTeleportOverlay().isCustomRunMode()
@@ -944,7 +948,7 @@ public class EasyFarmingOverlay extends Overlay {
                 return Integer.compare(priority1, priority2);
             });
 
-            plugin.setTeleportOverlayActive(allItemsCollected);
+            plugin.setTeleportOverlayActive(allItemsCollected && !needsLunarSpellbook);
 
             // Update InfoBoxes - remove ones that are no longer needed, add/update ones
             // that are
@@ -1010,7 +1014,7 @@ public class EasyFarmingOverlay extends Overlay {
             }
 
             // Check if all items have been collected
-            if (missingItemsWithCounts.isEmpty()) {
+            if (missingItemsWithCounts.isEmpty() && !needsLunarSpellbook) {
                 plugin.setItemsCollected(true);
             } else {
                 plugin.setItemsCollected(false);

--- a/src/main/java/com/easyfarming/EasyFarmingOverlay.java
+++ b/src/main/java/com/easyfarming/EasyFarmingOverlay.java
@@ -1110,6 +1110,7 @@ public class EasyFarmingOverlay extends Overlay {
         if (itemId == ItemID.BUCKET_COMPOST ||
                 itemId == ItemID.BUCKET_SUPERCOMPOST ||
                 itemId == ItemID.BUCKET_ULTRACOMPOST ||
+                itemId == ItemID.FOSSIL_VOLCANIC_ASH ||
                 Constants.BOTTOMLESS_COMPOST_BUCKET_ITEM_IDS.contains(itemId)) {
             return true;
         }

--- a/src/main/java/com/easyfarming/EasyFarmingOverlay.java
+++ b/src/main/java/com/easyfarming/EasyFarmingOverlay.java
@@ -913,6 +913,8 @@ public class EasyFarmingOverlay extends Overlay {
                 } else if (itemId == ItemID.PENDANT_OF_ATES) {
                     boolean hasPendant = inventoryItemCounts.getOrDefault(ItemID.PENDANT_OF_ATES, 0) > 0;
                     inventoryCount = hasPendant ? count : 0;
+                } else if (itemId == Constants.BASE_HERB_SACK_ID) {
+                    inventoryCount = hasAnyItem(inventoryItemCounts, Constants.ANY_HERB_SACK_IDS) ? 1 : 0;
                 }
 
                 // Rune pouch contents are already included in inventoryItemCounts
@@ -1071,6 +1073,7 @@ public class EasyFarmingOverlay extends Overlay {
                 itemId == ItemID.RAKE ||
                 itemId == ItemID.DIBBER ||
                 itemId == ItemID.FAIRY_ENCHANTED_SECATEURS ||
+                itemId == Constants.BASE_HERB_SACK_ID ||
                 isWateringCan(itemId);
     }
 
@@ -1126,6 +1129,15 @@ public class EasyFarmingOverlay extends Overlay {
 
         // Everything else (runes, teleport items, tools, etc.) is considered a teleport
         // item
+        return false;
+    }
+
+    private boolean hasAnyItem(Map<Integer, Integer> itemCounts, List<Integer> itemIds) {
+        for (int itemId : itemIds) {
+            if (itemCounts.getOrDefault(itemId, 0) > 0) {
+                return true;
+            }
+        }
         return false;
     }
 }

--- a/src/main/java/com/easyfarming/core/Location.java
+++ b/src/main/java/com/easyfarming/core/Location.java
@@ -1,6 +1,7 @@
 package com.easyfarming.core;
 
 import com.easyfarming.EasyFarmingConfig;
+import com.easyfarming.utils.FertileSoilHelper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -38,7 +39,7 @@ public class Location {
             for (Teleport teleport : teleportOptions) {
                 String opt = teleport.getEnumOption();
                 if (opt != null && selectedEnumOption.equalsIgnoreCase(opt)) {
-                    return teleport;
+                    return effectiveTeleport(teleport);
                 }
             }
             // Custom run may store a teleport id from another patch type at the same location (e.g. tree
@@ -48,12 +49,26 @@ public class Location {
                 for (Teleport teleport : teleportOptions) {
                     String opt = teleport.getEnumOption();
                     if (opt != null && configEnumOption.equalsIgnoreCase(opt)) {
-                        return teleport;
+                        return effectiveTeleport(teleport);
                     }
                 }
             }
         }
-        return teleportOptions.isEmpty() ? null : teleportOptions.get(0);
+        return teleportOptions.isEmpty() ? null : effectiveTeleport(teleportOptions.get(0));
+    }
+
+    private Teleport effectiveTeleport(Teleport selectedTeleport) {
+        if (selectedTeleport != null
+                && selectedTeleport.getCategory() == Teleport.Category.SPELLBOOK
+                && FertileSoilHelper.avoidStandardSpellbookTeleports(config)) {
+            for (Teleport teleport : teleportOptions) {
+                if (teleport.getCategory() != Teleport.Category.SPELLBOOK
+                        && teleport.getCategory() != Teleport.Category.NONE) {
+                    return teleport;
+                }
+            }
+        }
+        return selectedTeleport;
     }
 
     public void setOverrideTeleportEnumOption(String enumOption) {

--- a/src/main/java/com/easyfarming/customrun/CustomRunItemRequirements.java
+++ b/src/main/java/com/easyfarming/customrun/CustomRunItemRequirements.java
@@ -4,6 +4,7 @@ import com.easyfarming.EasyFarmingConfig;
 import com.easyfarming.core.Location;
 import com.easyfarming.core.Teleport;
 import com.easyfarming.utils.Constants;
+import com.easyfarming.utils.FertileSoilHelper;
 import com.easyfarming.utils.TeleportItemRequirements;
 import net.runelite.api.Client;
 import net.runelite.api.gameval.ItemID;
@@ -66,6 +67,9 @@ public final class CustomRunItemRequirements {
 
             Map<Integer, Integer> req = teleport.getItemRequirements();
             mergeTeleportRequirements(allRequirements, req);
+            if (teleport.getCategory() == Teleport.Category.SPELLBOOK && FertileSoilHelper.useSpellbookSwap(config)) {
+                FertileSoilHelper.mergeSpellbookSwapRunes(allRequirements, 1);
+            }
 
             for (String patchType : patchTypes) {
                 if (PatchTypes.HERB.equals(patchType)) {
@@ -99,13 +103,22 @@ public final class CustomRunItemRequirements {
 
         boolean payForProtection = config != null && config.generalPayForProtection();
         if (!payForProtection) {
-            Integer selectedCompost = selectedCompostId(config);
-            int compostId = selectedCompost != null ? selectedCompost : -1;
-            if (compostId != -1 && compostId != 0) {
-                if (compostId == ItemID.BOTTOMLESS_COMPOST_BUCKET) {
-                    allRequirements.merge(ItemID.BOTTOMLESS_COMPOST_BUCKET, 1, Integer::sum);
-                } else {
-                    allRequirements.merge(compostId, compostPatchesTotal, Integer::sum);
+            if (FertileSoilHelper.usesFertileSoil(config)) {
+                allRequirements.merge(ItemID.EARTHRUNE, Constants.FERTILE_SOIL_EARTH_RUNE_COUNT * compostPatchesTotal, Integer::sum);
+                allRequirements.merge(ItemID.NATURERUNE, Constants.FERTILE_SOIL_NATURE_RUNE_COUNT * compostPatchesTotal, Integer::sum);
+                allRequirements.merge(ItemID.ASTRALRUNE, Constants.FERTILE_SOIL_ASTRAL_RUNE_COUNT * compostPatchesTotal, Integer::sum);
+                if (FertileSoilHelper.usesVolcanicAsh(config)) {
+                    allRequirements.merge(ItemID.FOSSIL_VOLCANIC_ASH, Constants.FERTILE_SOIL_VOLCANIC_ASH_COUNT * compostPatchesTotal, Integer::sum);
+                }
+            } else {
+                Integer selectedCompostId = selectedCompostId(config);
+                int compostId = selectedCompostId != null ? selectedCompostId : -1;
+                if (compostId != -1 && compostId != 0) {
+                    if (compostId == ItemID.BOTTOMLESS_COMPOST_BUCKET) {
+                        allRequirements.merge(ItemID.BOTTOMLESS_COMPOST_BUCKET, 1, Integer::sum);
+                    } else {
+                        allRequirements.merge(compostId, compostPatchesTotal, Integer::sum);
+                    }
                 }
             }
         }
@@ -174,6 +187,9 @@ public final class CustomRunItemRequirements {
                 return ItemID.BUCKET_ULTRACOMPOST;
             case Bottomless:
                 return ItemID.BOTTOMLESS_COMPOST_BUCKET;
+            case Fertile_Soil:
+            case Fertile_Soil_Ash_Covered_Tome:
+                return 0;
             default:
                 return 0;
         }

--- a/src/main/java/com/easyfarming/customrun/CustomRunItemRequirements.java
+++ b/src/main/java/com/easyfarming/customrun/CustomRunItemRequirements.java
@@ -125,6 +125,9 @@ public final class CustomRunItemRequirements {
 
         if (herbPatchCount > 0) {
             allRequirements.merge(ItemID.GUAM_SEED, herbPatchCount, Integer::sum);
+            if (config != null && config.useHerbSack()) {
+                allRequirements.merge(Constants.BASE_HERB_SACK_ID, 1, Integer::sum);
+            }
         }
         if (flowerPatchCount > 0) {
             allRequirements.merge(ItemID.LIMPWURT_SEED, flowerPatchCount, Integer::sum);

--- a/src/main/java/com/easyfarming/overlays/handlers/FarmingStepHandler.java
+++ b/src/main/java/com/easyfarming/overlays/handlers/FarmingStepHandler.java
@@ -90,6 +90,9 @@ public class FarmingStepHandler {
 
     private String compostInstruction(String patchDescription) {
         if (FertileSoilHelper.usesFertileSoil(config)) {
+            if (FertileSoilHelper.needsLunarSpellbook(client, config)) {
+                return FertileSoilHelper.SWITCH_TO_LUNAR_SPELLBOOK_INSTRUCTION;
+            }
             return "Cast Fertile Soil on " + patchDescription + ".";
         }
         return "Use Compost on " + patchDescription + ".";

--- a/src/main/java/com/easyfarming/overlays/handlers/FarmingStepHandler.java
+++ b/src/main/java/com/easyfarming/overlays/handlers/FarmingStepHandler.java
@@ -6,6 +6,7 @@ import com.easyfarming.overlays.highlighting.*;
 import com.easyfarming.overlays.utils.ColorProvider;
 import com.easyfarming.overlays.utils.PatchStateChecker;
 import com.easyfarming.utils.Constants;
+import com.easyfarming.utils.FertileSoilHelper;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
 import net.runelite.api.ObjectComposition;
@@ -79,6 +80,13 @@ public class FarmingStepHandler {
         this.colorProvider = colorProvider;
         this.farmingHelperOverlay = farmingHelperOverlay;
         this.gameObjectHighlighter = gameObjectHighlighter;
+    }
+
+    private String compostInstruction(String patchDescription) {
+        if (FertileSoilHelper.usesFertileSoil(config)) {
+            return "Cast Fertile Soil on " + patchDescription + ".";
+        }
+        return "Use Compost on " + patchDescription + ".";
     }
     
     /**
@@ -209,7 +217,7 @@ public class FarmingStepHandler {
                         return;
                     }
                     // Patch is GROWING but not composted yet - show compost instruction
-                    plugin.addTextToInfoBox("Use Compost on patch.");
+                    plugin.addTextToInfoBox(compostInstruction("patch"));
                     Integer compostId = itemHighlighter.selectedCompostID();
                     // If compost is not in inventory, set hint arrow to Tool Leprechaun
                     if (compostId != null && !itemHighlighter.isItemInInventory(compostId)) {
@@ -340,7 +348,7 @@ public class FarmingStepHandler {
                             return;
                         }
                         // Patch is GROWING but not composted yet - show compost instruction
-                        plugin.addTextToInfoBox("Use Compost on patch.");
+                        plugin.addTextToInfoBox(compostInstruction("patch"));
                         patchHighlighter.highlightSpecificHopsPatch(graphics, patchObjectId, useItemColor);
                         Integer compostId = itemHighlighter.selectedCompostID();
                         // If compost is not in inventory, set hint arrow to Tool Leprechaun
@@ -498,7 +506,7 @@ public class FarmingStepHandler {
                             return;
                         }
                         // Patch is GROWING but not composted yet - show compost instruction
-                        plugin.addTextToInfoBox("Use Compost on patch.");
+                        plugin.addTextToInfoBox(compostInstruction("patch"));
                         patchHighlighter.highlightSpecificFlowerPatch(graphics, patchObjectId, useItemColor);
                         compostHighlighter.highlightCompost(graphics, false, false, false, 2);
                         break;
@@ -853,7 +861,7 @@ public class FarmingStepHandler {
                         return;
                     }
                     // Patch is GROWING but not composted yet - show compost instruction
-                    plugin.addTextToInfoBox("Use Compost on north patch.");
+                    plugin.addTextToInfoBox(compostInstruction("north patch"));
                     patchHighlighter.highlightSpecificAllotmentPatch(graphics, patchObjectId, useItemColor);
                     Integer compostId = itemHighlighter.selectedCompostID();
                     if (compostId != null && itemHighlighter.isItemInInventory(compostId)) {
@@ -1014,7 +1022,7 @@ public class FarmingStepHandler {
                         return; // Don't show compost instruction if already composted
                     }
                     // Patch is GROWING but not composted yet - show compost instruction
-                    plugin.addTextToInfoBox("Use Compost on south patch.");
+                    plugin.addTextToInfoBox(compostInstruction("south patch"));
                     patchHighlighter.highlightSpecificAllotmentPatch(graphics, patchObjectId, useItemColor);
                     Integer compostId = itemHighlighter.selectedCompostID();
                     if (compostId != null && itemHighlighter.isItemInInventory(compostId)) {
@@ -1138,7 +1146,7 @@ public class FarmingStepHandler {
                             return;
                         }
                         // Patch is GROWING but not composted yet - show compost instruction
-                        plugin.addTextToInfoBox("Use Compost on patch.");
+                        plugin.addTextToInfoBox(compostInstruction("patch"));
                         Integer compostId = itemHighlighter.selectedCompostID();
                         // If compost is not in inventory, set hint arrow to Tool Leprechaun
                         if (compostId != null && !itemHighlighter.isItemInInventory(compostId)) {
@@ -1283,7 +1291,7 @@ public class FarmingStepHandler {
                             return;
                         }
                         // Patch is GROWING but not composted yet - show compost instruction
-                        plugin.addTextToInfoBox("Use Compost on patch.");
+                        plugin.addTextToInfoBox(compostInstruction("patch"));
                         Integer compostId = itemHighlighter.selectedCompostID();
                         // If compost is not in inventory, set hint arrow to Tool Leprechaun
                         if (compostId != null && !itemHighlighter.isItemInInventory(compostId)) {

--- a/src/main/java/com/easyfarming/overlays/handlers/FarmingStepHandler.java
+++ b/src/main/java/com/easyfarming/overlays/handlers/FarmingStepHandler.java
@@ -55,6 +55,12 @@ public class FarmingStepHandler {
     private boolean treePatchComposted = false;
     private boolean fruitTreePatchComposted = false;
     private boolean hopsPatchComposted = false;
+
+    private boolean herbPatchNeedsCompost = false;
+    private boolean flowerPatchNeedsCompost = false;
+    private boolean treePatchNeedsCompost = false;
+    private boolean fruitTreePatchNeedsCompost = false;
+    private boolean hopsPatchNeedsCompost = false;
     
     // Allotment patch tracking - which patch we're currently working on (0 = first patch, 1 = second patch)
     private final AllotmentPatchState allotmentPatchState = new AllotmentPatchState();
@@ -87,6 +93,11 @@ public class FarmingStepHandler {
             return "Cast Fertile Soil on " + patchDescription + ".";
         }
         return "Use Compost on " + patchDescription + ".";
+    }
+
+    private boolean fertileSoilIsBlockedForHerbPatch(String locationName) {
+        return FertileSoilHelper.usesFertileSoil(config)
+                && "Troll Stronghold".equals(locationName);
     }
     
     /**
@@ -137,6 +148,11 @@ public class FarmingStepHandler {
         if (teleport == null) {
             // Transitioning between locations; navigation overlay handles routing.
         } else {
+            if (plantState != HerbPatchChecker.PlantState.GROWING
+                    && plantState != HerbPatchChecker.PlantState.UNKNOWN) {
+                herbPatchNeedsCompost = true;
+            }
+
             switch (plantState) {
                 case HARVESTABLE:
                     plugin.addTextToInfoBox("Harvest Herbs.");
@@ -214,6 +230,18 @@ public class FarmingStepHandler {
                         // Clear hint arrow when patch is done
                         clearHintArrow();
                         // Don't show anything - transition will happen on next frame
+                        return;
+                    }
+                    if (!herbPatchNeedsCompost) {
+                        herbPatchComposted = true;
+                        herbPatchDone = true;
+                        clearHintArrow();
+                        return;
+                    }
+                    if (fertileSoilIsBlockedForHerbPatch(locationName)) {
+                        herbPatchComposted = true;
+                        herbPatchDone = true;
+                        clearHintArrow();
                         return;
                     }
                     // Patch is GROWING but not composted yet - show compost instruction
@@ -294,6 +322,11 @@ public class FarmingStepHandler {
             // Highlight all hops patches when far from patch and no state detected
             patchHighlighter.highlightHopsPatches(graphics, leftColor);
         } else {
+            if (plantState != HopsPatchChecker.PlantState.GROWING
+                    && plantState != HopsPatchChecker.PlantState.UNKNOWN) {
+                hopsPatchNeedsCompost = true;
+            }
+
             // Highlight specific patch for current location
             if (patchObjectId != null) {
                 switch (plantState) {
@@ -343,6 +376,12 @@ public class FarmingStepHandler {
                         boolean isComposted = patchStateChecker.patchIsCompostedForHopsPatch();
                         if (isComposted) {
                             hopsPatchComposted = true;  // Set persistent state
+                            hopsPatchDone = true;
+                            clearHintArrow();
+                            return;
+                        }
+                        if (!hopsPatchNeedsCompost) {
+                            hopsPatchComposted = true;
                             hopsPatchDone = true;
                             clearHintArrow();
                             return;
@@ -450,6 +489,12 @@ public class FarmingStepHandler {
             if (varbitId != -1) {
                 plantState = FlowerPatchChecker.checkFlowerPatch(client, varbitId);
             }
+
+            if (plantState != FlowerPatchChecker.PlantState.GROWING
+                    && plantState != FlowerPatchChecker.PlantState.UNKNOWN) {
+                flowerPatchNeedsCompost = true;
+            }
+
             // Always highlight specific patch if patchObjectId is available, similar to herb patches
             if (patchObjectId != null) {
                 switch (plantState) {
@@ -501,6 +546,12 @@ public class FarmingStepHandler {
                         boolean isComposted = patchStateChecker.patchIsCompostedForFlowerPatch();
                         if (isComposted) {
                             flowerPatchComposted = true;  // Set persistent state
+                            flowerPatchDone = true;
+                            clearHintArrow();
+                            return;
+                        }
+                        if (!flowerPatchNeedsCompost) {
+                            flowerPatchComposted = true;
                             flowerPatchDone = true;
                             clearHintArrow();
                             return;
@@ -799,9 +850,18 @@ public class FarmingStepHandler {
             plantState = AllotmentPatchChecker.checkAllotmentPatch(client, varbitId);
         }
 
+        if (plantState != AllotmentPatchChecker.PlantState.GROWING
+                && plantState != AllotmentPatchChecker.PlantState.UNKNOWN) {
+            allotmentPatchState.markNeedsCompost(0);
+        }
+
         // Check completion status for north patch
         // HARVESTABLE is NOT completed - user still needs to harvest
         // Only GROWING + composted is considered completed (nothing more to do)
+        if (plantState == AllotmentPatchChecker.PlantState.GROWING
+                && !allotmentPatchState.patchNeedsCompost(0)) {
+            allotmentPatchState.markComposted(0);
+        }
         boolean completed = plantState == AllotmentPatchChecker.PlantState.GROWING && allotmentPatchState.isPatchComposted(0);
         allotmentPatchState.setPatchCompleted(0, completed);
         
@@ -857,6 +917,11 @@ public class FarmingStepHandler {
                         // Mark as composted (persistent)
                         allotmentPatchState.markComposted(0);
                         // Clear hint arrow when patch is composted
+                        clearHintArrow();
+                        return;
+                    }
+                    if (!allotmentPatchState.patchNeedsCompost(0)) {
+                        allotmentPatchState.markComposted(0);
                         clearHintArrow();
                         return;
                     }
@@ -932,11 +997,20 @@ public class FarmingStepHandler {
             plantState = AllotmentPatchChecker.checkAllotmentPatch(client, varbitId);
         }
 
+        if (plantState != AllotmentPatchChecker.PlantState.GROWING
+                && plantState != AllotmentPatchChecker.PlantState.UNKNOWN) {
+            allotmentPatchState.markNeedsCompost(1);
+        }
+
         // Check completion status for south patch
         // HARVESTABLE is NOT completed - user still needs to harvest
         // Only GROWING + composted is considered completed (nothing more to do)
         // Don't mark as completed if it's GROWING but not composted yet
         if (!allotmentPatchState.isPatchCompleted(1)) {
+            if (plantState == AllotmentPatchChecker.PlantState.GROWING
+                    && !allotmentPatchState.patchNeedsCompost(1)) {
+                allotmentPatchState.markComposted(1);
+            }
             if (plantState == AllotmentPatchChecker.PlantState.GROWING && allotmentPatchState.isPatchComposted(1)) {
                 allotmentPatchState.setPatchCompleted(1, true);
             }
@@ -1013,6 +1087,11 @@ public class FarmingStepHandler {
                         clearHintArrow();
                         return;
                     }
+                    if (!allotmentPatchState.patchNeedsCompost(1)) {
+                        allotmentPatchState.markComposted(1);
+                        clearHintArrow();
+                        return;
+                    }
                     // Safety check: If already composted (shouldn't reach here due to early return, but just in case)
                     if (allotmentPatchState.isPatchComposted(1)) {
                         // Patch is already composted, mark as completed and return
@@ -1080,6 +1159,11 @@ public class FarmingStepHandler {
         if (teleport == null) {
             // Transitioning between locations.
         } else {
+            if (plantState != TreePatchChecker.PlantState.GROWING
+                    && plantState != TreePatchChecker.PlantState.UNKNOWN) {
+                treePatchNeedsCompost = true;
+            }
+
             switch (plantState) {
                 case HEALTHY:
                     plugin.addTextToInfoBox("Check tree health.");
@@ -1141,6 +1225,12 @@ public class FarmingStepHandler {
                         boolean isComposted = patchStateChecker.patchIsCompostedForTreePatch();
                         if (isComposted) {
                             treePatchComposted = true;  // Set persistent state
+                            treePatchDone = true;
+                            clearHintArrow();
+                            return;
+                        }
+                        if (!treePatchNeedsCompost) {
+                            treePatchComposted = true;
                             treePatchDone = true;
                             clearHintArrow();
                             return;
@@ -1215,6 +1305,11 @@ public class FarmingStepHandler {
         if (teleport == null) {
             // Transitioning between locations.
         } else {
+            if (plantState != FruitTreePatchChecker.PlantState.GROWING
+                    && plantState != FruitTreePatchChecker.PlantState.UNKNOWN) {
+                fruitTreePatchNeedsCompost = true;
+            }
+
             switch (plantState) {
                 case HEALTHY:
                     plugin.addTextToInfoBox("Check Fruit tree health.");
@@ -1286,6 +1381,12 @@ public class FarmingStepHandler {
                         boolean isComposted = patchStateChecker.patchIsCompostedForFruitTreePatch();
                         if (isComposted) {
                             fruitTreePatchComposted = true;  // Set persistent state
+                            fruitTreePatchDone = true;
+                            clearHintArrow();
+                            return;
+                        }
+                        if (!fruitTreePatchNeedsCompost) {
+                            fruitTreePatchComposted = true;
                             fruitTreePatchDone = true;
                             clearHintArrow();
                             return;
@@ -1533,6 +1634,7 @@ public class FarmingStepHandler {
         private int currentIndex = 0;
         private final boolean[] completed = new boolean[2]; // Track completion of each patch
         private final boolean[] composted = new boolean[2]; // Track compost state per patch independently
+        private final boolean[] needsCompost = new boolean[2]; // Patch changed during this run and should be composted
         
         /**
          * Gets the current patch index (0 = north patch, 1 = south patch).
@@ -1564,6 +1666,20 @@ public class FarmingStepHandler {
                 throw new IllegalArgumentException("Invalid patch index: " + index);
             }
             return composted[index];
+        }
+
+        public boolean patchNeedsCompost(int index) {
+            if (index < 0 || index >= needsCompost.length) {
+                throw new IllegalArgumentException("Invalid patch index: " + index);
+            }
+            return needsCompost[index];
+        }
+
+        public void markNeedsCompost(int index) {
+            if (index < 0 || index >= needsCompost.length) {
+                throw new IllegalArgumentException("Invalid patch index: " + index);
+            }
+            needsCompost[index] = true;
         }
         
         /**
@@ -1609,6 +1725,8 @@ public class FarmingStepHandler {
             completed[1] = false;
             composted[0] = false;
             composted[1] = false;
+            needsCompost[0] = false;
+            needsCompost[1] = false;
         }
     }
 
@@ -1621,6 +1739,12 @@ public class FarmingStepHandler {
         treePatchComposted = false;
         fruitTreePatchComposted = false;
         hopsPatchComposted = false;
+
+        herbPatchNeedsCompost = false;
+        flowerPatchNeedsCompost = false;
+        treePatchNeedsCompost = false;
+        fruitTreePatchNeedsCompost = false;
+        hopsPatchNeedsCompost = false;
     }
 }
 

--- a/src/main/java/com/easyfarming/overlays/handlers/NavigationHandler.java
+++ b/src/main/java/com/easyfarming/overlays/handlers/NavigationHandler.java
@@ -8,6 +8,7 @@ import com.easyfarming.overlays.utils.ColorProvider;
 import com.easyfarming.overlays.utils.GameObjectHelper;
 import com.easyfarming.overlays.utils.WidgetHelper;
 import com.easyfarming.utils.Constants;
+import com.easyfarming.utils.FertileSoilHelper;
 import net.runelite.api.Client;
 import net.runelite.api.Player;
 import net.runelite.api.coords.WorldPoint;
@@ -83,7 +84,7 @@ public class NavigationHandler {
      * Handles navigation to player's house.
      */
     public void gettingToHouse(Graphics2D graphics) {
-        EasyFarmingConfig.OptionEnumHouseTele teleportOption = config.enumConfigHouseTele();
+        EasyFarmingConfig.OptionEnumHouseTele teleportOption = FertileSoilHelper.effectiveHouseTeleport(config);
         Color leftColor = colorProvider.getLeftClickColorWithAlpha();
         Color rightColor = colorProvider.getRightClickColorWithAlpha();
         
@@ -98,8 +99,13 @@ public class NavigationHandler {
                         widgetHighlighter.interfaceOverlay(widgetHelper.getSpellbookIconGroupId(), widgetHelper.getSpellbookIconChildId()).render(graphics);
                         break;
                     case SPELLBOOK:
-                        // Highlight the "Teleport to House" spell using correct child ID from widget inspector
-                        widgetHighlighter.interfaceOverlay(InterfaceID.MAGIC_SPELLBOOK, Constants.SPELL_CHILD_TELEPORT_TO_HOUSE).render(graphics);
+                        if (FertileSoilHelper.useSpellbookSwap(config)
+                                && !widgetHelper.isInterfaceOpen(InterfaceID.MAGIC_SPELLBOOK, Constants.SPELL_CHILD_TELEPORT_TO_HOUSE)) {
+                            widgetHighlighter.interfaceOverlay(InterfaceID.MAGIC_SPELLBOOK, Constants.SPELL_CHILD_SPELLBOOK_SWAP).render(graphics);
+                        } else {
+                            // Highlight the "Teleport to House" spell using correct child ID from widget inspector
+                            widgetHighlighter.interfaceOverlay(InterfaceID.MAGIC_SPELLBOOK, Constants.SPELL_CHILD_TELEPORT_TO_HOUSE).render(graphics);
+                        }
                         inHouseCheck();
                         break;
                 }
@@ -568,7 +574,12 @@ public class NavigationHandler {
                 }
                 break;
             case SPELLBOOK:
-                widgetHighlighter.interfaceOverlay(teleport.getInterfaceGroupId(), teleport.getInterfaceChildId()).render(graphics);
+                if (FertileSoilHelper.useSpellbookSwap(config)
+                        && !widgetHelper.isInterfaceOpen(teleport.getInterfaceGroupId(), teleport.getInterfaceChildId())) {
+                    widgetHighlighter.interfaceOverlay(InterfaceID.MAGIC_SPELLBOOK, Constants.SPELL_CHILD_SPELLBOOK_SWAP).render(graphics);
+                } else {
+                    widgetHighlighter.interfaceOverlay(teleport.getInterfaceGroupId(), teleport.getInterfaceChildId()).render(graphics);
+                }
                 if (currentRegionId == teleport.getRegionId()) {
                     this.currentTeleportCase = 1;
                     isAtDestination = true;

--- a/src/main/java/com/easyfarming/overlays/handlers/NavigationHandler.java
+++ b/src/main/java/com/easyfarming/overlays/handlers/NavigationHandler.java
@@ -10,7 +10,12 @@ import com.easyfarming.overlays.utils.WidgetHelper;
 import com.easyfarming.utils.Constants;
 import com.easyfarming.utils.FertileSoilHelper;
 import net.runelite.api.Client;
+import net.runelite.api.DecorativeObject;
+import net.runelite.api.GameObject;
+import net.runelite.api.GroundObject;
 import net.runelite.api.Player;
+import net.runelite.api.Tile;
+import net.runelite.api.WorldView;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.ItemID;
@@ -72,12 +77,92 @@ public class NavigationHandler {
     }
     
     /**
-     * Checks if player is in their house (has Portal object).
+     * Checks if player is in their house.
      */
     public void inHouseCheck() {
-        if (gameObjectHelper.getGameObjectIdsByName("Portal").contains(4525)) {
+        if (isPlayerInHouse()) {
             this.currentTeleportCase = 2;
         }
+    }
+
+    private boolean isPlayerInHouse() {
+        return !gameObjectHelper.getGameObjectIdsByName("Portal").isEmpty()
+                || !gameObjectHelper.getGameObjectIdsByName("Portal Nexus").isEmpty()
+                || !gameObjectHelper.getGameObjectIdsByName("Jewellery Box").isEmpty()
+                || !gameObjectHelper.getGameObjectIdsByName("Jewellery box").isEmpty()
+                || !gameObjectHighlighter.findGameObjectsByID(Constants.POH_EXIT_PORTAL_OBJECT_ID).isEmpty()
+                || hasAnyGameObject(Constants.POH_PORTAL_NEXUS_IDS)
+                || hasAnyGameObject(Constants.JEWELLERY_BOX_IDS)
+                || hasAnyDecorativeObject(Constants.XERICS_TALISMAN_IDS)
+                || liveSceneHasPohObject();
+    }
+
+    private boolean hasAnyGameObject(List<Integer> objectIds) {
+        for (int objectId : objectIds) {
+            if (!gameObjectHighlighter.findGameObjectsByID(objectId).isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasAnyDecorativeObject(List<Integer> objectIds) {
+        for (int objectId : objectIds) {
+            if (!gameObjectHighlighter.findDecorativeObjectsByID(objectId).isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean liveSceneHasPohObject() {
+        WorldView worldView = getPlayerWorldView();
+        if (worldView == null || worldView.getScene() == null) {
+            return false;
+        }
+
+        Tile[][][] tiles = worldView.getScene().getTiles();
+        for (int plane = 0; plane < tiles.length; plane++) {
+            for (int x = 0; x < Constants.SCENE_SIZE; x++) {
+                for (int y = 0; y < Constants.SCENE_SIZE; y++) {
+                    Tile tile = tiles[plane][x][y];
+                    if (tile == null) {
+                        continue;
+                    }
+
+                    for (GameObject gameObject : tile.getGameObjects()) {
+                        if (gameObject != null && isPohGameObject(gameObject.getId())) {
+                            return true;
+                        }
+                    }
+
+                    GroundObject groundObject = tile.getGroundObject();
+                    if (groundObject != null && isPohGameObject(groundObject.getId())) {
+                        return true;
+                    }
+
+                    DecorativeObject decorativeObject = tile.getDecorativeObject();
+                    if (decorativeObject != null && Constants.XERICS_TALISMAN_IDS.contains(decorativeObject.getId())) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean isPohGameObject(int objectId) {
+        return objectId == Constants.POH_EXIT_PORTAL_OBJECT_ID
+                || Constants.POH_PORTAL_NEXUS_IDS.contains(objectId)
+                || Constants.JEWELLERY_BOX_IDS.contains(objectId);
+    }
+
+    private WorldView getPlayerWorldView() {
+        Player localPlayer = client.getLocalPlayer();
+        if (localPlayer != null && localPlayer.getWorldView() != null) {
+            return localPlayer.getWorldView();
+        }
+        return client.getTopLevelWorldView();
     }
     
     /**
@@ -87,6 +172,13 @@ public class NavigationHandler {
         EasyFarmingConfig.OptionEnumHouseTele teleportOption = FertileSoilHelper.effectiveHouseTeleport(config);
         Color leftColor = colorProvider.getLeftClickColorWithAlpha();
         Color rightColor = colorProvider.getRightClickColorWithAlpha();
+
+        inHouseCheck();
+        if (currentTeleportCase == 2) {
+            return;
+        }
+
+        plugin.addTextToInfoBox(getHouseTeleportInstruction());
         
         switch (teleportOption) {
             case Law_air_earth_runes:
@@ -287,6 +379,16 @@ public class NavigationHandler {
         }
         
         // Default to normal teleport highlighting
+        if (requiresHouseNavigation(teleport) && currentTeleportCase == 1) {
+            inHouseCheck();
+            if (currentTeleportCase == 2) {
+                handleHouseDestinationTeleport(graphics, teleport, location, currentRegionId);
+                return;
+            }
+            gettingToHouse(graphics);
+            return;
+        }
+
         teleportHighlighter.highlightTeleportMethod(teleport, graphics);
     }
     
@@ -304,6 +406,10 @@ public class NavigationHandler {
                 return;
             }
             int currentRegionId = client.getLocalPlayer().getWorldLocation().getRegionID();
+
+            if (requiresHouseNavigation(teleport)) {
+                inHouseCheck();
+            }
             
             // Use adaptive detection to determine if we should proceed to farming
             if (shouldProceedToFarming(location, teleport)) {
@@ -316,7 +422,7 @@ public class NavigationHandler {
             } else {
                 // Use adaptive highlighting based on current situation
                 adaptiveHighlighting(location, teleport, graphics, patchType);
-                plugin.addTextToInfoBox(teleport.getDescription());
+                plugin.addTextToInfoBox(getNavigationInstruction(teleport));
                 return;
             }
             
@@ -350,6 +456,78 @@ public class NavigationHandler {
                     }
                     break;
             }
+        }
+    }
+
+    private boolean requiresHouseNavigation(Teleport teleport) {
+        if (teleport == null) {
+            return false;
+        }
+        switch (teleport.getCategory()) {
+            case PORTAL_NEXUS:
+            case JEWELLERY_BOX:
+            case MOUNTED_XERICS:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private String getNavigationInstruction(Teleport teleport) {
+        if (requiresHouseNavigation(teleport)) {
+            inHouseCheck();
+        }
+        if (requiresHouseNavigation(teleport) && currentTeleportCase == 1) {
+            return getHouseTeleportInstruction();
+        }
+        return teleport.getDescription();
+    }
+
+    private void handleHouseDestinationTeleport(Graphics2D graphics, Teleport teleport, Location location, int currentRegionId) {
+        switch (teleport.getCategory()) {
+            case PORTAL_NEXUS:
+                handlePortalNexusTeleport(graphics, teleport, location, currentRegionId);
+                break;
+            case JEWELLERY_BOX:
+                handleJewelleryBoxTeleport(graphics, teleport, location, currentRegionId);
+                break;
+            case MOUNTED_XERICS:
+                handleMountedXericsTeleport(graphics, teleport, location, currentRegionId);
+                break;
+            default:
+                teleportHighlighter.highlightTeleportMethod(teleport, graphics);
+                break;
+        }
+    }
+
+    private String getHouseTeleportInstruction() {
+        EasyFarmingConfig.OptionEnumHouseTele teleportOption = FertileSoilHelper.effectiveHouseTeleport(config);
+        switch (teleportOption) {
+            case Law_air_earth_runes:
+                InventoryTabChecker.TabState tabState = InventoryTabChecker.checkTab(client, VarClientID.TOPLEVEL_PANEL);
+                switch (tabState) {
+                    case INVENTORY:
+                    case REST:
+                        return "Open spellbook for Teleport to House.";
+                    case SPELLBOOK:
+                        if (FertileSoilHelper.useSpellbookSwap(config)
+                                && !widgetHelper.isInterfaceOpen(InterfaceID.MAGIC_SPELLBOOK, Constants.SPELL_CHILD_TELEPORT_TO_HOUSE)) {
+                            return "Cast Spellbook Swap for Teleport to House.";
+                        }
+                        return "Cast Teleport to House.";
+                    default:
+                        return "Cast Teleport to House.";
+                }
+            case Teleport_To_House:
+                return "Use Teleport to House tablet.";
+            case Construction_cape:
+                return "Use Construction cape to teleport home.";
+            case Construction_cape_t:
+                return "Use trimmed Construction cape to teleport home.";
+            case Max_cape:
+                return "Use Max cape to teleport home.";
+            default:
+                return "Teleport to your house.";
         }
     }
     
@@ -445,6 +623,7 @@ public class NavigationHandler {
                 if (!widgetHelper.isInterfaceOpen(17, 0)) {
                     List<Integer> portalNexusIds = gameObjectHelper.getGameObjectIdsByName("Portal Nexus");
                     gameObjectHighlighter.renderGameObjectHighlights(graphics, portalNexusIds, leftColor);
+                    gameObjectHighlighter.renderGameObjectHighlights(graphics, Constants.POH_PORTAL_NEXUS_IDS, leftColor);
                 } else {
                     Widget widget = client.getWidget(Constants.INTERFACE_PORTAL_NEXUS, Constants.INTERFACE_PORTAL_NEXUS_CHILD);
                     int index = widgetHelper.getChildIndexPortalNexus(location.getName());

--- a/src/main/java/com/easyfarming/overlays/highlighting/CompostHighlighter.java
+++ b/src/main/java/com/easyfarming/overlays/highlighting/CompostHighlighter.java
@@ -3,8 +3,10 @@ package com.easyfarming.overlays.highlighting;
 import com.easyfarming.EasyFarmingConfig;
 import com.easyfarming.overlays.utils.ColorProvider;
 import com.easyfarming.overlays.utils.PatchStateChecker;
+import com.easyfarming.overlays.utils.WidgetHelper;
 import com.easyfarming.utils.Constants;
 import net.runelite.api.Client;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.widgets.Widget;
 
@@ -21,6 +23,7 @@ public class CompostHighlighter {
     private final PatchHighlighter patchHighlighter;
     private final NPCHighlighter npcHighlighter;
     private final WidgetHighlighter widgetHighlighter;
+    private final WidgetHelper widgetHelper;
     private final PatchStateChecker patchStateChecker;
     private final ColorProvider colorProvider;
     
@@ -28,13 +31,15 @@ public class CompostHighlighter {
     public CompostHighlighter(Client client, EasyFarmingConfig config, 
                              ItemHighlighter itemHighlighter, PatchHighlighter patchHighlighter,
                              NPCHighlighter npcHighlighter, WidgetHighlighter widgetHighlighter,
-                             PatchStateChecker patchStateChecker, ColorProvider colorProvider) {
+                             WidgetHelper widgetHelper, PatchStateChecker patchStateChecker,
+                             ColorProvider colorProvider) {
         this.client = client;
         this.config = config;
         this.itemHighlighter = itemHighlighter;
         this.patchHighlighter = patchHighlighter;
         this.npcHighlighter = npcHighlighter;
         this.widgetHighlighter = widgetHighlighter;
+        this.widgetHelper = widgetHelper;
         this.patchStateChecker = patchStateChecker;
         this.colorProvider = colorProvider;
     }
@@ -46,8 +51,29 @@ public class CompostHighlighter {
                                 boolean fruitTreeRun, int subCase) {
         Integer compostId = itemHighlighter.selectedCompostID();
         Color color = colorProvider.getHighlightUseItemWithAlpha();
+
+        if (itemHighlighter.selectedCompostUsesFertileSoil()) {
+            if (herbRun) {
+                if (subCase == 1) {
+                    patchHighlighter.highlightHerbPatches(graphics, color);
+                } else if (subCase == 2) {
+                    patchHighlighter.highlightFlowerPatches(graphics, color);
+                }
+            }
+
+            if (treeRun) {
+                patchHighlighter.highlightTreePatches(graphics, color);
+            }
+
+            if (fruitTreeRun) {
+                patchHighlighter.highlightFruitTreePatches(graphics, color);
+            }
+
+            highlightFertileSoilCast(graphics);
+            return;
+        }
         
-        if (itemHighlighter.isItemInInventory(compostId)) {
+        if (compostId != null && itemHighlighter.isItemInInventory(compostId)) {
             if (herbRun) {
                 if (subCase == 1) {
                     patchHighlighter.highlightHerbPatches(graphics, color);
@@ -81,6 +107,11 @@ public class CompostHighlighter {
      * Highlights the Tool Leprechaun and interface for withdrawing compost.
      */
     public void withdrawCompost(Graphics2D graphics) {
+        if (itemHighlighter.selectedCompostUsesFertileSoil()) {
+            highlightFertileSoilCast(graphics);
+            return;
+        }
+
         if (!isInterfaceOpen(Constants.INTERFACE_TOOL_LEPRECHAUN, 0)) {
             npcHighlighter.highlightNpc(graphics, "Tool Leprechaun");
         } else {
@@ -94,6 +125,21 @@ public class CompostHighlighter {
             } else if (compostId == ItemID.BOTTOMLESS_COMPOST_BUCKET) {
                 widgetHighlighter.interfaceOverlay(Constants.INTERFACE_TOOL_LEPRECHAUN, 15).render(graphics);
             }
+        }
+    }
+
+    private void highlightFertileSoilCast(Graphics2D graphics) {
+        Color color = colorProvider.getHighlightUseItemWithAlpha();
+        if (itemHighlighter.selectedCompostUsesVolcanicAsh()) {
+            itemHighlighter.itemHighlight(graphics, ItemID.FOSSIL_VOLCANIC_ASH, color);
+        }
+
+        if (isInterfaceOpen(InterfaceID.MAGIC_SPELLBOOK, Constants.SPELL_CHILD_FERTILE_SOIL)) {
+            widgetHighlighter.interfaceOverlay(InterfaceID.MAGIC_SPELLBOOK, Constants.SPELL_CHILD_FERTILE_SOIL).render(graphics);
+        } else {
+            widgetHighlighter.interfaceOverlay(
+                    widgetHelper.getSpellbookIconGroupId(),
+                    widgetHelper.getSpellbookIconChildId()).render(graphics);
         }
     }
     

--- a/src/main/java/com/easyfarming/overlays/highlighting/CompostHighlighter.java
+++ b/src/main/java/com/easyfarming/overlays/highlighting/CompostHighlighter.java
@@ -5,6 +5,7 @@ import com.easyfarming.overlays.utils.ColorProvider;
 import com.easyfarming.overlays.utils.PatchStateChecker;
 import com.easyfarming.overlays.utils.WidgetHelper;
 import com.easyfarming.utils.Constants;
+import com.easyfarming.utils.FertileSoilHelper;
 import net.runelite.api.Client;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.ItemID;
@@ -130,6 +131,13 @@ public class CompostHighlighter {
 
     private void highlightFertileSoilCast(Graphics2D graphics) {
         Color color = colorProvider.getHighlightUseItemWithAlpha();
+        if (FertileSoilHelper.needsLunarSpellbook(client, config)) {
+            widgetHighlighter.interfaceOverlay(
+                    widgetHelper.getSpellbookIconGroupId(),
+                    widgetHelper.getSpellbookIconChildId()).render(graphics);
+            return;
+        }
+
         if (itemHighlighter.selectedCompostUsesVolcanicAsh()) {
             itemHighlighter.itemHighlight(graphics, ItemID.FOSSIL_VOLCANIC_ASH, color);
         }

--- a/src/main/java/com/easyfarming/overlays/highlighting/ItemHighlighter.java
+++ b/src/main/java/com/easyfarming/overlays/highlighting/ItemHighlighter.java
@@ -4,6 +4,7 @@ import com.easyfarming.EasyFarmingOverlay;
 import com.easyfarming.EasyFarmingConfig;
 import com.easyfarming.overlays.utils.ColorProvider;
 import com.easyfarming.utils.Constants;
+import com.easyfarming.utils.FertileSoilHelper;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
 import net.runelite.api.gameval.InventoryID;
@@ -310,8 +311,19 @@ public class ItemHighlighter {
                 return ItemID.BUCKET_ULTRACOMPOST;
             case Bottomless:
                 return ItemID.BOTTOMLESS_COMPOST_BUCKET;
+            case Fertile_Soil:
+            case Fertile_Soil_Ash_Covered_Tome:
+                return null;
         }
         return -1;
+    }
+
+    public boolean selectedCompostUsesFertileSoil() {
+        return FertileSoilHelper.usesFertileSoil(config);
+    }
+
+    public boolean selectedCompostUsesVolcanicAsh() {
+        return FertileSoilHelper.usesVolcanicAsh(config);
     }
     
     /**

--- a/src/main/java/com/easyfarming/overlays/highlighting/ItemHighlighter.java
+++ b/src/main/java/com/easyfarming/overlays/highlighting/ItemHighlighter.java
@@ -166,6 +166,7 @@ public class ItemHighlighter {
         return isQuetzalWhistleHighlight(itemId, targetId)
                 || isExplorersRingHighlight(itemId, targetId)
                 || isArdyCloakHighlight(itemId, targetId)
+                || isFarmingCapeHighlight(itemId, targetId)
                 || isSkillsNecklaceHighlight(itemId, targetId)
                 || isNecklaceOfPassageHighlight(itemId, targetId)
                 || isBottomlessBucketHighlight(itemId, targetId)
@@ -201,6 +202,13 @@ public class ItemHighlighter {
     }
     
     /**
+     * Checks if an item ID matches a Farming cape highlight pattern (untrimmed or trimmed).
+     */
+    private boolean isFarmingCapeHighlight(int itemId, int targetId) {
+        return farmingHelperOverlay.isFarmingCape(itemId) && farmingHelperOverlay.isFarmingCape(targetId);
+    }
+
+    /**
      * Checks if an item ID matches a Skills Necklace highlight pattern.
      */
     private boolean isSkillsNecklaceHighlight(int itemId, int targetId) {
@@ -231,34 +239,46 @@ public class ItemHighlighter {
     
     /**
      * Highlights allotment seeds in inventory.
+     * Also highlights the Seed Box (seeds can be planted directly from it).
      */
     public void highlightAllotmentSeeds(Graphics2D graphics) {
         Color useItemColor = colorProvider.getHighlightUseItemWithAlpha();
         highlightInventorySlotsWithIds(graphics, farmingHelperOverlay.getAllotmentSeedIds(), useItemColor);
+        highlightSeedBox(graphics, useItemColor);
     }
 
     /**
      * Highlights herb seeds in inventory.
+     * Also highlights the Seed Box (seeds can be planted directly from it).
      */
     public void highlightHerbSeeds(Graphics2D graphics) {
         Color color = colorProvider.getHighlightUseItemWithAlpha();
         highlightInventorySlotsWithIds(graphics, farmingHelperOverlay.getHerbSeedIds(), color);
+        highlightSeedBox(graphics, color);
     }
 
     /**
      * Highlights hops seeds in inventory.
+     * Also highlights the Seed Box (seeds can be planted directly from it).
      */
     public void highlightHopsSeeds(Graphics2D graphics) {
         Color color = colorProvider.getHighlightUseItemWithAlpha();
         highlightInventorySlotsWithIds(graphics, farmingHelperOverlay.getHopsSeedIds(), color);
+        highlightSeedBox(graphics, color);
     }
 
     /**
      * Highlights flower seeds in inventory (limpwurt, white lily, etc.).
+     * Also highlights the Seed Box (seeds can be planted directly from it).
      */
     public void highlightFlowerSeeds(Graphics2D graphics) {
         Color color = colorProvider.getHighlightUseItemWithAlpha();
         highlightInventorySlotsWithIds(graphics, farmingHelperOverlay.getFlowerSeedIds(), color);
+        highlightSeedBox(graphics, color);
+    }
+
+    private void highlightSeedBox(Graphics2D graphics, Color color) {
+        highlightInventorySlotsWithIds(graphics, farmingHelperOverlay.getSeedBoxIds(), color);
     }
 
     /**

--- a/src/main/java/com/easyfarming/overlays/highlighting/TeleportHighlighter.java
+++ b/src/main/java/com/easyfarming/overlays/highlighting/TeleportHighlighter.java
@@ -9,7 +9,9 @@ import com.easyfarming.overlays.utils.ColorProvider;
 import com.easyfarming.overlays.utils.GameObjectHelper;
 import com.easyfarming.overlays.utils.WidgetHelper;
 import com.easyfarming.utils.Constants;
+import com.easyfarming.utils.FertileSoilHelper;
 import net.runelite.api.Client;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.VarClientID;
 import net.runelite.api.widgets.Widget;
 
@@ -74,7 +76,12 @@ public class TeleportHighlighter {
             case SPELLBOOK:
                 InventoryTabChecker.TabState tabState = InventoryTabChecker.checkTab(client, VarClientID.TOPLEVEL_PANEL);
                 if (tabState == InventoryTabChecker.TabState.SPELLBOOK) {
-                    widgetHighlighter.interfaceOverlay(teleport.getInterfaceGroupId(), teleport.getInterfaceChildId()).render(graphics);
+                    if (FertileSoilHelper.useSpellbookSwap(plugin.getConfig())
+                            && !widgetHelper.isInterfaceOpen(teleport.getInterfaceGroupId(), teleport.getInterfaceChildId())) {
+                        widgetHighlighter.interfaceOverlay(InterfaceID.MAGIC_SPELLBOOK, Constants.SPELL_CHILD_SPELLBOOK_SWAP).render(graphics);
+                    } else {
+                        widgetHighlighter.interfaceOverlay(teleport.getInterfaceGroupId(), teleport.getInterfaceChildId()).render(graphics);
+                    }
                 } else {
                     // Highlight the spellbook icon in the tab bar (widget group 161/164, child 6)
                     widgetHighlighter.interfaceOverlay(widgetHelper.getSpellbookIconGroupId(), widgetHelper.getSpellbookIconChildId()).render(graphics);

--- a/src/main/java/com/easyfarming/overlays/utils/PatchStateChecker.java
+++ b/src/main/java/com/easyfarming/overlays/utils/PatchStateChecker.java
@@ -9,11 +9,14 @@ import java.util.regex.Pattern;
  * Utility class for checking patch states (composted, protected, etc.).
  */
 public class PatchStateChecker {
-    private static final String REGEX_COMPOST1 = "You treat the (herb patch|flower patch|allotment|tree patch|fruit tree patch|hops patch) with (compost|supercompost|ultracompost)\\.";
-    private static final String REGEX_COMPOST2 = "This (herb patch|flower patch|allotment|tree patch|fruit tree patch|hops patch) has already been treated with (compost|supercompost|ultracompost)\\.";
-    private static final String REGEX_COMPOST3 = "You treat the patch with (compost|supercompost|ultracompost)\\.";
-    private static final String REGEX_COMPOST4 = "This patch has already been treated with (compost|supercompost|ultracompost)\\.";
-    private static final Pattern COMPOST_PATTERN = Pattern.compile(REGEX_COMPOST1 + "|" + REGEX_COMPOST2 + "|" + REGEX_COMPOST3 + "|" + REGEX_COMPOST4);
+    private static final String COMPOST_TYPES = "compost|super ?compost|ultra ?compost";
+    private static final String REGEX_COMPOST1 = "You treat the (herb patch|flower patch|allotment|tree patch|fruit tree patch|hops patch) with (" + COMPOST_TYPES + ")\\.";
+    private static final String REGEX_COMPOST2 = "This (herb patch|flower patch|allotment|tree patch|fruit tree patch|hops patch) has already been treated with (" + COMPOST_TYPES + ")\\.";
+    private static final String REGEX_COMPOST3 = "You treat the patch with (" + COMPOST_TYPES + ")\\.";
+    private static final String REGEX_COMPOST4 = "This patch has already been treated with (" + COMPOST_TYPES + ")\\.";
+    private static final String REGEX_COMPOST5 = "(You|The spell) fertili[sz]es? the (herb patch|flower patch|allotment|tree patch|fruit tree patch|hops patch|patch) with (super ?compost|ultra ?compost)\\.";
+    private static final String REGEX_COMPOST6 = "The (herb patch|flower patch|allotment|tree patch|fruit tree patch|hops patch|patch) has been treated with (" + COMPOST_TYPES + ")( consuming [0-9]+ of your volcanic ash)?\\.";
+    private static final Pattern COMPOST_PATTERN = Pattern.compile(REGEX_COMPOST1 + "|" + REGEX_COMPOST2 + "|" + REGEX_COMPOST3 + "|" + REGEX_COMPOST4 + "|" + REGEX_COMPOST5 + "|" + REGEX_COMPOST6);
     
     private static final String STANDARD_RESPONSE = "You pay the gardener ([0-9A-Za-z\\ ]+) to protect the patch\\.";
     private static final String FALADOR_ELITE_RESPONSE = "The gardener protects your tree for you, free of charge, as a token of gratitude for completing the ([A-Za-z\\ ]+)\\.";
@@ -88,7 +91,10 @@ public class PatchStateChecker {
     }
 
     private static boolean isGenericPatchCompostMessage(String lastMessage) {
-        return lastMessage.contains("treat the patch with") || lastMessage.contains("This patch has already");
+        return lastMessage.contains("treat the patch with")
+                || lastMessage.contains("fertilise the patch with")
+                || lastMessage.contains("fertilize the patch with")
+                || lastMessage.contains("This patch has already");
     }
 
     /**

--- a/src/main/java/com/easyfarming/utils/Constants.java
+++ b/src/main/java/com/easyfarming/utils/Constants.java
@@ -407,6 +407,12 @@ public class Constants {
     public static final List<Integer> JEWELLERY_BOX_IDS = Collections.unmodifiableList(Arrays.asList(
         29154, 29155, 29156
     ));
+
+    public static final int POH_EXIT_PORTAL_OBJECT_ID = 4525;
+
+    public static final List<Integer> POH_PORTAL_NEXUS_IDS = Collections.unmodifiableList(Arrays.asList(
+        13647
+    ));
     
     /**
      * Decorative object IDs for mounted Xeric's talisman in the POH (used with

--- a/src/main/java/com/easyfarming/utils/Constants.java
+++ b/src/main/java/com/easyfarming/utils/Constants.java
@@ -432,9 +432,27 @@ public class Constants {
     public static final int BASE_SKILLS_NECKLACE_ID = ItemID.JEWL_NECKLACE_OF_SKILLS_1;
     public static final int BASE_NECKLACE_OF_PASSAGE_ID = ItemID.NECKLACE_OF_PASSAGE_5;
     public static final int BASE_HERB_SEED_ID = ItemID.GUAM_SEED;
+    public static final int BASE_HERB_SACK_ID = ItemID.SLAYER_HERB_SACK;
     public static final int BASE_TREE_SAPLING_ID = ItemID.PLANTPOT_OAK_SAPLING;
     public static final int BASE_FRUIT_TREE_SAPLING_ID = ItemID.PLANTPOT_APPLE_SAPLING;
     public static final int BASE_ALLOTMENT_SEED_ID = ItemID.SNAPE_GRASS_SEED;
+
+    public static final List<Integer> HERB_SACK_IDS = Collections.unmodifiableList(Arrays.asList(
+        ItemID.SLAYER_HERB_SACK,
+        ItemID.SLAYER_HERB_SACK_OPEN
+    ));
+
+    public static final List<Integer> SILKLINED_HERB_SACK_IDS = Collections.unmodifiableList(Arrays.asList(
+        ItemID.SLAYER_HERB_SACK_SILK,
+        ItemID.SLAYER_HERB_SACK_SILK_OPEN
+    ));
+
+    public static final List<Integer> ANY_HERB_SACK_IDS = Collections.unmodifiableList(Arrays.asList(
+        ItemID.SLAYER_HERB_SACK,
+        ItemID.SLAYER_HERB_SACK_OPEN,
+        ItemID.SLAYER_HERB_SACK_SILK,
+        ItemID.SLAYER_HERB_SACK_SILK_OPEN
+    ));
     
     // Combination rune mapping
     public static final Map<Integer, List<Integer>> COMBINATION_RUNE_SUBRUNES_MAP;

--- a/src/main/java/com/easyfarming/utils/Constants.java
+++ b/src/main/java/com/easyfarming/utils/Constants.java
@@ -381,7 +381,8 @@ public class Constants {
     ));
     
     public static final List<Integer> RUNE_POUCH_IDS = Collections.unmodifiableList(Arrays.asList(
-        ItemID.BH_RUNE_POUCH, ItemID.DIVINE_RUNE_POUCH
+        ItemID.BH_RUNE_POUCH, ItemID.BH_RUNE_POUCH_TROUVER,
+        ItemID.DIVINE_RUNE_POUCH, ItemID.DIVINE_RUNE_POUCH_TROUVER
     ));
     
     public static final List<Integer> RUNE_POUCH_AMOUNT_VARBITS = Collections.unmodifiableList(Arrays.asList(
@@ -392,6 +393,11 @@ public class Constants {
     public static final List<Integer> RUNE_POUCH_RUNE_VARBITS = Collections.unmodifiableList(Arrays.asList(
         VarbitID.RUNE_POUCH_TYPE_1, VarbitID.RUNE_POUCH_TYPE_2,
         VarbitID.RUNE_POUCH_TYPE_3, VarbitID.RUNE_POUCH_TYPE_4
+    ));
+
+    /** Closed and open Seed Box item IDs (Tithe Farm reward). Not ItemID.SEEDBOX (seed pack). */
+    public static final List<Integer> SEED_BOX_IDS = Collections.unmodifiableList(Arrays.asList(
+        ItemID.SEED_BOX, ItemID.SEED_BOX_OPEN
     ));
     
     public static final List<Integer> SPIRIT_TREE_IDS = Collections.unmodifiableList(Arrays.asList(
@@ -523,6 +529,10 @@ public class Constants {
 
     public static boolean isFlowerSeed(int itemId) {
         return FLOWER_SEED_IDS.contains(itemId);
+    }
+
+    public static boolean isSeedBox(int itemId) {
+        return SEED_BOX_IDS.contains(itemId);
     }
     
     public static boolean isQuetzalWhistle(int itemId) {

--- a/src/main/java/com/easyfarming/utils/Constants.java
+++ b/src/main/java/com/easyfarming/utils/Constants.java
@@ -1,5 +1,6 @@
 package com.easyfarming.utils;
 
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.ObjectID;
 import net.runelite.api.gameval.VarbitID;
@@ -99,6 +100,18 @@ public class Constants {
     public static final int SPELL_CHILD_FORTIS_TELEPORT = 46;
     public static final int SPELL_CHILD_WATCHTOWER_TELEPORT = 50;
     public static final int SPELL_CHILD_TELEPORT_TO_HOUSE = 34;
+    public static final int SPELL_CHILD_FERTILE_SOIL = InterfaceID.MagicSpellbook.FERTILE_SOIL & 0xFFFF;
+    public static final int SPELL_CHILD_SPELLBOOK_SWAP = InterfaceID.MagicSpellbook.SPELLBOOK_SWAP & 0xFFFF;
+
+    // Fertile Soil applies supercompost. With the ash covered tome unlock, two volcanic ash
+    // are consumed to upgrade the cast to ultracompost.
+    public static final int FERTILE_SOIL_EARTH_RUNE_COUNT = 15;
+    public static final int FERTILE_SOIL_NATURE_RUNE_COUNT = 2;
+    public static final int FERTILE_SOIL_ASTRAL_RUNE_COUNT = 3;
+    public static final int FERTILE_SOIL_VOLCANIC_ASH_COUNT = 2;
+    public static final int SPELLBOOK_SWAP_ASTRAL_RUNE_COUNT = 3;
+    public static final int SPELLBOOK_SWAP_COSMIC_RUNE_COUNT = 2;
+    public static final int SPELLBOOK_SWAP_LAW_RUNE_COUNT = 1;
 
     public static boolean isKastoriRegion(int regionId) {
         return regionId == REGION_KASTORI

--- a/src/main/java/com/easyfarming/utils/FertileSoilHelper.java
+++ b/src/main/java/com/easyfarming/utils/FertileSoilHelper.java
@@ -1,11 +1,16 @@
 package com.easyfarming.utils;
 
 import com.easyfarming.EasyFarmingConfig;
+import net.runelite.api.Client;
 import net.runelite.api.gameval.ItemID;
+import net.runelite.api.gameval.VarbitID;
 
 import java.util.Map;
 
 public final class FertileSoilHelper {
+    private static final int LUNAR_SPELLBOOK = 2;
+    public static final String SWITCH_TO_LUNAR_SPELLBOOK_INSTRUCTION = "Switch to the Lunar spellbook.";
+
     private FertileSoilHelper() {}
 
     public static boolean usesFertileSoil(EasyFarmingConfig config) {
@@ -29,6 +34,14 @@ public final class FertileSoilHelper {
 
     public static boolean avoidStandardSpellbookTeleports(EasyFarmingConfig config) {
         return usesFertileSoil(config) && !useSpellbookSwap(config);
+    }
+
+    public static boolean isOnLunarSpellbook(Client client) {
+        return client != null && client.getVarbitValue(VarbitID.SPELLBOOK) == LUNAR_SPELLBOOK;
+    }
+
+    public static boolean needsLunarSpellbook(Client client, EasyFarmingConfig config) {
+        return usesFertileSoil(config) && !isOnLunarSpellbook(client);
     }
 
     public static EasyFarmingConfig.OptionEnumHouseTele effectiveHouseTeleport(EasyFarmingConfig config) {

--- a/src/main/java/com/easyfarming/utils/FertileSoilHelper.java
+++ b/src/main/java/com/easyfarming/utils/FertileSoilHelper.java
@@ -1,0 +1,54 @@
+package com.easyfarming.utils;
+
+import com.easyfarming.EasyFarmingConfig;
+import net.runelite.api.gameval.ItemID;
+
+import java.util.Map;
+
+public final class FertileSoilHelper {
+    private FertileSoilHelper() {}
+
+    public static boolean usesFertileSoil(EasyFarmingConfig config) {
+        if (config == null) {
+            return false;
+        }
+        EasyFarmingConfig.OptionEnumCompost compost = config.enumConfigCompost();
+        return compost == EasyFarmingConfig.OptionEnumCompost.Fertile_Soil
+                || compost == EasyFarmingConfig.OptionEnumCompost.Fertile_Soil_Ash_Covered_Tome;
+    }
+
+    public static boolean usesVolcanicAsh(EasyFarmingConfig config) {
+        return config != null
+                && config.enumConfigCompost() == EasyFarmingConfig.OptionEnumCompost.Fertile_Soil_Ash_Covered_Tome;
+    }
+
+    public static boolean useSpellbookSwap(EasyFarmingConfig config) {
+        return usesFertileSoil(config)
+                && config.fertileSoilTeleportMode() == EasyFarmingConfig.OptionEnumFertileSoilTeleportMode.Use_Spellbook_Swap;
+    }
+
+    public static boolean avoidStandardSpellbookTeleports(EasyFarmingConfig config) {
+        return usesFertileSoil(config) && !useSpellbookSwap(config);
+    }
+
+    public static EasyFarmingConfig.OptionEnumHouseTele effectiveHouseTeleport(EasyFarmingConfig config) {
+        if (config == null) {
+            return EasyFarmingConfig.OptionEnumHouseTele.Law_air_earth_runes;
+        }
+        EasyFarmingConfig.OptionEnumHouseTele selected = config.enumConfigHouseTele();
+        if (avoidStandardSpellbookTeleports(config)
+                && selected == EasyFarmingConfig.OptionEnumHouseTele.Law_air_earth_runes) {
+            return EasyFarmingConfig.OptionEnumHouseTele.Teleport_To_House;
+        }
+        return selected;
+    }
+
+    public static void mergeSpellbookSwapRunes(Map<Integer, Integer> requirements, int casts) {
+        if (requirements == null || casts <= 0) {
+            return;
+        }
+        requirements.merge(ItemID.ASTRALRUNE, Constants.SPELLBOOK_SWAP_ASTRAL_RUNE_COUNT * casts, Integer::sum);
+        requirements.merge(ItemID.COSMICRUNE, Constants.SPELLBOOK_SWAP_COSMIC_RUNE_COUNT * casts, Integer::sum);
+        requirements.merge(ItemID.LAWRUNE, Constants.SPELLBOOK_SWAP_LAW_RUNE_COUNT * casts, Integer::sum);
+    }
+}

--- a/src/main/java/com/easyfarming/utils/TeleportItemRequirements.java
+++ b/src/main/java/com/easyfarming/utils/TeleportItemRequirements.java
@@ -19,14 +19,19 @@ public final class TeleportItemRequirements {
     private TeleportItemRequirements() {}
 
     public static List<ItemRequirement> getHouseTeleportItemRequirements(EasyFarmingConfig config) {
-        EasyFarmingConfig.OptionEnumHouseTele selectedOption = config.enumConfigHouseTele();
+        EasyFarmingConfig.OptionEnumHouseTele selectedOption = FertileSoilHelper.effectiveHouseTeleport(config);
         List<ItemRequirement> itemRequirements = new ArrayList<>();
 
         switch (selectedOption) {
             case Law_air_earth_runes:
+                if (FertileSoilHelper.useSpellbookSwap(config)) {
+                    itemRequirements.add(new ItemRequirement(ItemID.ASTRALRUNE, Constants.SPELLBOOK_SWAP_ASTRAL_RUNE_COUNT));
+                    itemRequirements.add(new ItemRequirement(ItemID.COSMICRUNE, Constants.SPELLBOOK_SWAP_COSMIC_RUNE_COUNT));
+                }
                 itemRequirements.add(new ItemRequirement(ItemID.AIRRUNE, 1));
                 itemRequirements.add(new ItemRequirement(ItemID.EARTHRUNE, 1));
-                itemRequirements.add(new ItemRequirement(ItemID.LAWRUNE, 1));
+                itemRequirements.add(new ItemRequirement(ItemID.LAWRUNE,
+                        1 + (FertileSoilHelper.useSpellbookSwap(config) ? Constants.SPELLBOOK_SWAP_LAW_RUNE_COUNT : 0)));
                 break;
 
             case Teleport_To_House:


### PR DESCRIPTION
## Summary

Adds Fertile Soil support as a compost option for farming runs, including the Ash covered tome upgrade for ultracompost.

## Changes

- Added Fertile Soil and FS + Tome compost options
- Added rune and volcanic ash requirements for Fertile Soil casts
- Added Fertile Soil spell highlighting
- Added Spellbook Swap support for standard spellbook teleports while using Fertile Soil
- Added an indicator when Fertile Soil is selected but the player is not on the Lunar spellbook
- Skips Fertile Soil for Troll Stronghold herb patch, where protection is handled by Drunken Dwarf's Leg
- Added an optional herb sack requirement for herb runs
- Improved handling for patches that are already growing so the run can continue to the next farmable patch

## Testing

- Ran Gradle tests successfully
- Tested in-game across herb run flow, Fertile Soil casting, Spellbook Swap / Teleport to House flow, and growing patch behavior

## Notes

Opening as WIP while I continue validating edge cases in-game.
UPDATE: Done a couple of runs, everything appears to be working as intended, not running into anything weird.